### PR TITLE
Stable average chart

### DIFF
--- a/lib/actions/PPKActions.js
+++ b/lib/actions/PPKActions.js
@@ -229,7 +229,7 @@ export function open(serialPort) {
             triggerOptions.timestamp = timestamp;
             if (getState().app.average.averageRunning) {
                 const padAvgChart = Math.trunc(triggerData.length / SAMPLES_PER_AVERAGE);
-                for (let i = 0; i < padAvgChart; i += 1) {
+                for (let i = 0; i < padAvgChart - 6; i += 1) {
                     averageOptions.data[averageOptions.index] = 0;
                     averageOptions.index += 1;
                     if (averageOptions.index === averageOptions.data.length) {

--- a/lib/actions/rtt.js
+++ b/lib/actions/rtt.js
@@ -313,7 +313,7 @@ export async function start(serialNumber) {
 }
 
 export async function read() {
-    if (!RTT.isOpen) return;
+    if (!isRttOpen) return;
     try {
         const { rawbytes } = await readRTT(MAX_RTT_READ_LENGTH);
         if (rawbytes && rawbytes.length) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -34,9 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-const transport = 'rtt';
-
-export const ADC_SAMPLING_TIME_US = (transport === 'uart' ? 18 : 15);
+export const ADC_SAMPLING_TIME_US = 15;
 export const SAMPLES_PER_AVERAGE = 10;
 export const AVERAGE_TIME_US = SAMPLES_PER_AVERAGE * ADC_SAMPLING_TIME_US;
 export const TRIGGER_SAMPLES_PER_SECOND = 1e6 / ADC_SAMPLING_TIME_US;


### PR DESCRIPTION
The changes here together with @chriswils 's latest firmware makes it possible get rid of the jitter of average data, since the timestamps are generated by the hardware and are sent before both average and trigger stream.

- Added timestamp handling to stabilize and synchronize charts
- Moved constants to separate file
- Added constants for hardcoded values
- Removed unused serialPort, cleaned some console logs
- Refactored data handling in parseMeasurementData()