### PR TITLE
Update required nrfconnect engine to ^2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Nordic Semiconductor ASA",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "nrfconnect": "2.x"
+    "nrfconnect": "^2.3.0"
   },
   "main": "dist/bundle.js",
   "files": [


### PR DESCRIPTION
The PPK depends on RTT, which was introduced in pc-nrfjprog-js 1.2.0. The pc-nrfconnect-core versions prior to 2.3.0 came with an older version of pc-nrfjprog-js, so the app will not work for core versions below 2.3.0.

Updating the engine config so that users get a warning when trying to launch the app on older pc-nrfconnect-core versions.