### PR TITLE
Modified colors and colored areas for selection in chart

### DIFF
--- a/lib/utils/chart.dragSelect.js
+++ b/lib/utils/chart.dragSelect.js
@@ -38,6 +38,9 @@
 
 const Chart = require('chart.js');
 
+const CHART_SELECTION_COLOR = 'hsla(60, 50%, 70%, 1.0)';
+const CHART_DRAG_COLOR = 'hsla(210, 50%, 70%, 0.8)';
+
 const dragSelectPlugin = {
     id: 'dragSelect',
 
@@ -96,7 +99,7 @@ const dragSelectPlugin = {
         canvas.addEventListener('mouseup', dragSelect.mouseUpHandler);
     },
 
-    beforeDatasetsDraw(chartInstance) {
+    beforeDraw(chartInstance) {
         const { chartArea, chart } = chartInstance;
         const { ctx } = chart;
         const { left, right, top, bottom } = chartArea;
@@ -104,30 +107,25 @@ const dragSelectPlugin = {
         ctx.save();
         ctx.beginPath();
 
-        const { dragStart, dragEnd } = chartInstance.dragSelect;
-        if (dragStart && dragEnd) {
-            const offsetX = dragStart.target.getBoundingClientRect().left;
-            const startX = Math.min(dragStart.clientX, dragEnd.clientX) - offsetX;
-            const endX = Math.max(dragStart.clientX, dragEnd.clientX) - offsetX;
-            ctx.fillStyle = 'hsla(210, 100%, 36%, 0.2)';
-            ctx.fillRect(left, top, startX - left, bottom - top);
-            ctx.fillRect(endX, top, right - endX, bottom - top);
-        }
-
         const { scale } = chartInstance.dragSelect;
         const { cursor } = scale.options;
 
         if (cursor.cursorBegin) {
             const { cursorBegin, cursorEnd } = cursor;
-            const startX = scale.getPixelForValue(cursorBegin).valueOf();
-            const endX = scale.getPixelForValue(cursorEnd).valueOf();
-            ctx.fillStyle = 'hsla(0, 100%, 0%, 0.2)';
-            ctx.fillRect(left, top, startX - left, bottom - top);
-            ctx.fillRect(endX, top, right - endX, bottom - top);
+            const startX = Math.max(scale.getPixelForValue(cursorBegin).valueOf(), left);
+            const endX = Math.min(scale.getPixelForValue(cursorEnd).valueOf(), right);
+            ctx.fillStyle = CHART_SELECTION_COLOR;
+            ctx.fillRect(startX, top, endX - startX, bottom - top);
         }
-    },
 
-    afterDatasetsDraw(chartInstance) {
+        const { dragStart, dragEnd } = chartInstance.dragSelect;
+        if (dragStart && dragEnd) {
+            const offsetX = dragStart.target.getBoundingClientRect().left;
+            const startX = Math.max(Math.min(dragStart.clientX, dragEnd.clientX) - offsetX, left);
+            const endX = Math.min(Math.max(dragStart.clientX, dragEnd.clientX) - offsetX, right);
+            ctx.fillStyle = CHART_DRAG_COLOR;
+            ctx.fillRect(startX, top, endX - startX, bottom - top);
+        }
         chartInstance.chart.ctx.restore();
     },
 


### PR DESCRIPTION
- changed colored areas to be the actual selection and not the inversion of it
- fixed min and max coordinate of selection, so it cannot draw outside of chart area
- changed colors a bit for these areas, light blue is while dragging, yellow is the selected area

![ppk-colors](https://user-images.githubusercontent.com/26139379/35734081-23dd002e-0820-11e8-82a6-15de6fd1a1ce.png)
