### PR TITLE
Added button for reset window, added icons for chart buttons

### DIFF
--- a/lib/components/Chart.jsx
+++ b/lib/components/Chart.jsx
@@ -40,7 +40,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defaults, Line } from 'react-chartjs-2';
-import { Button, ButtonGroup } from 'react-bootstrap';
+import { Button, ButtonGroup, Glyphicon } from 'react-bootstrap';
 import math from 'mathjs';
 
 import '../utils/chart.dragSelect'; // eslint-disable-line
@@ -83,6 +83,7 @@ class Chart extends React.Component {
         this.resizeLength(0);
         this.onChartSizeUpdate = this.onChartSizeUpdate.bind(this);
         this.zoomPanCallback = this.zoomPanCallback.bind(this);
+        this.chartResetToLive = this.zoomPanCallback.bind(this, undefined, undefined);
         this.dragSelectCallback = this.dragSelectCallback.bind(this);
         this.resetCursor = this.dragSelectCallback.bind(this, 0, 0);
     }
@@ -317,8 +318,21 @@ class Chart extends React.Component {
                 <div className="chart-bottom">
                     {this.renderStats()}
                     <ButtonGroup>
-                        <Button bsStyle="primary" bsSize="small" onClick={this.resetCursor}>
-                            Clear Cursor
+                        <Button
+                            bsStyle="primary"
+                            bsSize="small"
+                            onClick={this.resetCursor}
+                            title="Clear Cursor"
+                        >
+                            <Glyphicon glyph="erase" />
+                        </Button>
+                        <Button
+                            bsStyle="primary"
+                            bsSize="small"
+                            onClick={this.chartResetToLive}
+                            title="Reset & Live"
+                        >
+                            <Glyphicon glyph="repeat" />
                         </Button>
                     </ButtonGroup>
                 </div>


### PR DESCRIPTION
Reset window functionality now has an button. In order to save space, *Clear Window* and *Reset & Live* buttons are now presented with icon and tooltip.

![ppk-cc](https://user-images.githubusercontent.com/26139379/35794667-e7d24f92-0a56-11e8-83a5-c32385f8cb36.png)
![ppk-rl](https://user-images.githubusercontent.com/26139379/35794668-e7eb492a-0a56-11e8-81d7-e3eab2dfd1ad.png)
