### PR TITLE
Make sure test passes on Node.js v6

### DIFF
--- a/lib/reducers/__tests__/resistorCalibrationReducer-test.js
+++ b/lib/reducers/__tests__/resistorCalibrationReducer-test.js
@@ -34,6 +34,13 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* eslint-disable import/first */
+
+jest.mock('../../actions/PPKActions', () => ({
+    PPK_METADATA: 'PPK_METADATA',
+    RESISTORS_RESET: 'RESISTORS_RESET',
+}));
+
 import reducer from '../resistorCalibrationReducer';
 import * as UiActions from '../../actions/uiActions';
 


### PR DESCRIPTION
The build is failing on the CI server because of a syntax error when running tests. This is happening because resistorCalibrationReducer.js (which we are testing) is importing PPKActions.js, and that file is
using async/await syntax. Support for async/await was added in Node.js 7.6, but our CI server runs Node.js 6.12.

As a temporary workaround, we can mock PPKActions.js to avoid parsing it when running tests on the CI server.