### PR TITLE
Fixes close/open not handled properly...

### DIFF
--- a/lib/actions/rtt.js
+++ b/lib/actions/rtt.js
@@ -297,6 +297,7 @@ export async function start(serialNumber) {
             if (err) {
                 return reject(err);
             }
+            isRttOpen = true;
             return resolve();
         });
     });
@@ -329,7 +330,6 @@ export async function start(serialNumber) {
         if (userResLo) userResLo = parseFloat(userResLo);
         if (userResMid) userResMid = parseFloat(userResMid);
         if (userResHi) userResHi = parseFloat(userResHi);
-        isRttOpen = true;
 
         return {
             version,


### PR DESCRIPTION
when ppk connection fails due to e.g wrong board selected.
Moving the `isRttOpen` flag to when RTT is actually opened to read the metadata. This means that if metadata fails to be read (e.g connecting to a dk without a ppk connection), `readRTT` will not continue to be called in `read()`