### PR TITLE
Replace links to old wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See the [InfoCenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct
 
 ## Development
 
-See the [app development](https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki) pages for details on how to develop apps for the nRF Connect for Desktop framework.
+See the [app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/) pages for details on how to develop apps for the nRF Connect for Desktop framework.
 
 ## Feedback
 
@@ -25,7 +25,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 
 ## Contributing
 
-See the [Contributing](https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki/Contributing) file for details.
+See the [infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing) for details.
 
 ## License
 


### PR DESCRIPTION
Similar to NordicSemiconductor/pc-nrfconnect-gettingstarted#7:

Because we are moving from https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki to https://nordicsemiconductor.github.io/pc-nrfconnect-docs/.