### PR TITLE
Correct reference to project core/launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nRF Connect Power Profiler
 
-Power Profiler app for [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-core).
+Power Profiler app for [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher).
 
 ## Introduction
 


### PR DESCRIPTION
This is part of [NCP-2704](https://projecttools.nordicsemi.no/jira/browse/NCP-2704).

The project `pc-nrfconnect-core` was renamed to `pc-nrfconnect-launcher`. This corrects references to the old name (links are redirected but it might still be confusing to keep on using the old name).