### PR TITLE
Harden against new serialport version

### DIFF
--- a/lib/actions/serialDevice.js
+++ b/lib/actions/serialDevice.js
@@ -39,14 +39,15 @@ import SerialPort from 'serialport';
 class SerialDevice {
     constructor(device, emitter, parseMeasurementData) {
         this.emit = emitter.emit.bind(emitter);
-        this.comName = device.serialport.comName;
+        // Prefer to use the serialport 8 property or fall back to the serialport 7 property
+        this.path = device.serialport.path || device.serialport.comName;
         this.parseMeasurementData = parseMeasurementData;
         this.port = null;
     }
 
     start() {
         return new Promise((resolve, reject) => {
-            this.port = new SerialPort(this.comName, { autoOpen: false });
+            this.port = new SerialPort(this.path, { autoOpen: false });
             this.port.open(err => {
                 if (err) {
                     return reject(err);


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

This enables the app to run with either serialport 7 (which had `comName` as a property) or serialport 8 (which moved to the property `path` and warns when still using comName).