### PR TITLE
Swap begin and end indexes if end handle is moved past begin handle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+## Fixed
+- Fix issue where moving the right handle past the left handle in the chart selection would break the values displayed in the selection window.
+
 ## Version 3.0.0
 ### Changed
 - Complete rewrite of the application. This version supports the old power profiler kit, in addition to the newly released PPK2 hardware.

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -147,9 +147,14 @@ const bitsChartOptions = {
     legend: { display: false },
 };
 
-const calcStats = (data, begin, end, index) => {
-    if (begin === null || end === null) {
+const calcStats = (data, _begin, _end, index) => {
+    if (_begin === null || _end === null) {
         return null;
+    }
+    let begin = _begin;
+    let end = _end;
+    if (end < begin) {
+        [begin, end] = [end, begin];
     }
     const indexBegin = Math.ceil(timestampToIndex(begin, index));
     const indexEnd = Math.floor(timestampToIndex(end, index));


### PR DESCRIPTION
This pull request should fix the issue where moving the right handle past the left handle in the chart selection would break the values displayed in the selection window.