### PR TITLE
Refactor trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2940,28 +2940,6 @@
         "es-abstract": "^1.18.0-next.1",
         "get-intrinsic": "^1.0.1",
         "is-string": "^1.0.5"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "array-unique": {
@@ -2978,6 +2956,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.4"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "array.prototype.flat": {
@@ -2989,28 +2988,6 @@
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "arrify": {
@@ -3726,9 +3703,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001161",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-      "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
+      "version": "1.0.30001164",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
+      "integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg==",
       "dev": true
     },
     "capture-exit": {
@@ -4499,18 +4476,18 @@
       "dev": true
     },
     "csso": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.1.1.tgz",
-      "integrity": "sha512-Rvq+e1e0TFB8E8X+8MQjHSY6vtol45s5gxtLI/018UsAn2IBMmwNEZRM/h+HVnAJRHjasLIKKUO3uvoMM28LvA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
       "dev": true,
       "requires": {
-        "css-tree": "^1.0.0"
+        "css-tree": "^1.1.2"
       },
       "dependencies": {
         "css-tree": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.1.tgz",
-          "integrity": "sha512-NVN42M2fjszcUNpDbdkvutgQSlFYsr1z7kqeuCagHnNLBfYor6uP1WL1KrkmdYZ5Y1vTBCIOI/C/+8T98fJ71w==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.2.tgz",
+          "integrity": "sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==",
           "dev": true,
           "requires": {
             "mdn-data": "2.0.14",
@@ -4899,9 +4876,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.607",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.607.tgz",
-      "integrity": "sha512-h2SYNaBnlplGS0YyXl8oJWokfcNxVjJANQfMCsQefG6OSuAuNIeW+A8yGT/ci+xRoBb3k2zq1FrOvkgoKBol8g==",
+      "version": "1.3.612",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.612.tgz",
+      "integrity": "sha512-CdrdX1B6mQqxfw+51MPWB5qA6TKWjza9f5voBtUlRfEZEwZiFaxJLrhFI8zHE9SBAuGt4h84rQU6Ho9Bauo1LA==",
       "dev": true
     },
     "elliptic": {
@@ -5120,9 +5097,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -5130,6 +5107,7 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
         "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
         "is-regex": "^1.1.1",
         "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
@@ -5713,9 +5691,9 @@
       "dev": true
     },
     "eslint-webpack-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.4.0.tgz",
-      "integrity": "sha512-j0lAJj3RnStAFdIH2P0+nsEImiBijwogZhL1go4bI6DE+9OhQuOmJ/xtmxkLtNr1w0cf5SRNkDlmIe8t/pHgww==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.4.1.tgz",
+      "integrity": "sha512-cj8iPWZKuAiVD8MMgTSunyMCAvxQxp5mxoPHZl1UMGkApFXaXJHdCFcCR+oZEJbBNhReNa5SjESIn34uqUbBtg==",
       "dev": true,
       "requires": {
         "@types/eslint": "^7.2.4",
@@ -6526,14 +6504,15 @@
       "dev": true
     },
     "function.prototype.name": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
-      "integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.3.tgz",
+      "integrity": "sha512-H51qkbNSp8mtkJt+nyW1gyStBiKZxfRqySNUR99ylq6BPXHKI4SEvIlTKp4odLfjRKJV04DFWMU3G/YRlQOsag==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "functions-have-names": "^1.2.0"
+        "es-abstract": "^1.18.0-next.1",
+        "functions-have-names": "^1.2.1"
       }
     },
     "functional-red-black-tree": {
@@ -7280,6 +7259,27 @@
         "es-abstract": "^1.17.0-next.1",
         "has": "^1.0.3",
         "side-channel": "^1.0.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "invariant": {
@@ -7376,9 +7376,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
-      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -9555,15 +9555,16 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
-    "lodash.range": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
-      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=",
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.range": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
+      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=",
       "dev": true
     },
     "lodash.sortby": {
@@ -9941,9 +9942,9 @@
       "dev": true
     },
     "nearley": {
-      "version": "2.19.8",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.8.tgz",
-      "integrity": "sha512-te4JCrxbzLvVqUWfVOASgsbkWaFvJ6JlHTRQzfnU862bnyHGHEGX2s5OYvLAS4NDPmQvRtC2tBdV6THy6xHFyQ==",
+      "version": "2.19.9",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.9.tgz",
+      "integrity": "sha512-KpCXvcVWPmZrEs95tIkqWi+CgL48O8CJDVDgY/AQGWXR1O8KQPHt5iQrTLior0k0v3PGKIV2xPi879wR1sawwg==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -10179,41 +10180,19 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true
     },
     "object-is": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
-      "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
+      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "object-keys": {
@@ -10244,36 +10223,38 @@
       }
     },
     "object.entries": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-      "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
+        "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
       }
     },
     "object.fromentries": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
-      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
+      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
+        "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
+      "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "object.pick": {
@@ -10286,14 +10267,14 @@
       }
     },
     "object.values": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
+      "integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
+        "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
       }
     },
@@ -10761,9 +10742,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.0.tgz",
-      "integrity": "sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -11398,6 +11379,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "regexpp": {
@@ -11945,28 +11947,6 @@
       "requires": {
         "es-abstract": "^1.18.0-next.0",
         "object-inspect": "^1.8.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "signal-exit": {
@@ -12221,9 +12201,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
-      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
     "split-string": {
@@ -12402,28 +12382,6 @@
         "internal-slot": "^1.0.2",
         "regexp.prototype.flags": "^1.3.0",
         "side-channel": "^1.0.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "string.prototype.trim": {
@@ -12435,28 +12393,6 @@
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "string.prototype.trimend": {
@@ -13324,6 +13260,27 @@
         "es-abstract": "^1.17.2",
         "has-symbols": "^1.0.1",
         "object.getownpropertydescriptors": "^2.1.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "uuid": {
@@ -13885,9 +13842,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9559,6 +9559,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
       "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=",
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.sortby": {
@@ -11323,6 +11328,15 @@
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
       "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==",
       "dev": true
+    },
+    "redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
+      }
     },
     "redux-thunk": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "react": "16.13.1",
     "react-chartjs-2": "2.9.0",
     "react-dom": "^17.0.1",
-    "react-redux": "7.2.0"
+    "react-redux": "7.2.0",
+    "redux-mock-store": "^1.5.4"
   },
   "dependencies": {},
   "eslintConfig": {

--- a/src/actions/__tests__/triggerActions-test.js
+++ b/src/actions/__tests__/triggerActions-test.js
@@ -1,0 +1,256 @@
+/* Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { processTriggerSample, calculateWindowSize } from '../triggerActions';
+import { indexToTimestamp } from '../../globals';
+
+jest.mock('nrfconnect/core', () => {
+    return {
+        logger: {
+            info: jest.fn(),
+        },
+    };
+});
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+const mockPpk2Device = {
+    numberOfSamplesIn5Ms: 500,
+    ppkTriggerStop: jest.fn(),
+};
+
+const defaultTriggerLength = 10;
+const defaultTriggerLevel = 10;
+const initialState = {
+    app: {
+        chart: {
+            preSamplingOn: false,
+            postSamplingOn: false,
+        },
+        trigger: {
+            triggerLength: defaultTriggerLength,
+            triggerLevel: defaultTriggerLevel,
+            triggerSingleWaiting: false,
+            triggerStartIndex: null,
+        },
+    },
+};
+const initialIndex = 5;
+const samplingData = {
+    dataIndex: initialIndex,
+    samplingTime: 10,
+    dataBuffer: new Array(2000).fill(100),
+};
+
+describe('Handle trigger', () => {
+    describe('window sizes', () => {
+        it('should calculate window size', () => {
+            const windowSize = calculateWindowSize(
+                defaultTriggerLength,
+                samplingData.samplingTime,
+                initialState.app.chart.postSamplingOn,
+                mockPpk2Device.numberOfSamplesIn5Ms
+            );
+            expect(windowSize).toBe(1000);
+        });
+
+        it('should add 500 samples to the size if postSampling is on', () => {
+            const windowSize = calculateWindowSize(
+                defaultTriggerLength,
+                samplingData.samplingTime,
+                true,
+                mockPpk2Device.numberOfSamplesIn5Ms
+            );
+            expect(windowSize).toBe(1500);
+        });
+    });
+
+    it('should set triggerStart if value is higher than trigger level', () => {
+        const store = mockStore(initialState);
+        store.dispatch(processTriggerSample(15, mockPpk2Device, samplingData));
+        const expectedActions = [
+            { type: 'SET_TRIGGER_START', triggerStartIndex: initialIndex },
+        ];
+        expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('should chart window if enough samples have been processed', () => {
+        const newIndex = 1005;
+        const store = mockStore({
+            app: {
+                ...initialState.app,
+                trigger: {
+                    ...initialState.app.trigger,
+                    triggerStartIndex: initialIndex,
+                },
+            },
+        });
+        store.dispatch(
+            processTriggerSample(5, mockPpk2Device, {
+                ...samplingData,
+                dataIndex: newIndex,
+            })
+        );
+        const from = indexToTimestamp(initialIndex);
+        const to = indexToTimestamp(newIndex);
+        const expectedActions = [
+            {
+                type: 'CHART_WINDOW',
+                windowBegin: from,
+                windowEnd: to,
+                windowDuration: to - from,
+                yMax: undefined,
+                yMin: undefined,
+            },
+            { type: 'SET_TRIGGER_START', triggerStartIndex: null },
+        ];
+        expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    it('should move windowBegin by 500 samples if presampling is on', () => {
+        const startIndex = 600;
+        const endIndex = 1600;
+        const store = mockStore({
+            app: {
+                ...initialState.app,
+                chart: {
+                    ...initialState.app.chart,
+                    preSamplingOn: true,
+                },
+                trigger: {
+                    ...initialState.app.trigger,
+                    triggerStartIndex: startIndex,
+                },
+            },
+        });
+        store.dispatch(
+            processTriggerSample(5, mockPpk2Device, {
+                ...samplingData,
+                dataIndex: endIndex,
+            })
+        );
+        const from = indexToTimestamp(
+            startIndex - mockPpk2Device.numberOfSamplesIn5Ms
+        );
+        const to = indexToTimestamp(endIndex);
+        const expectedActions = [
+            {
+                type: 'CHART_WINDOW',
+                windowBegin: from,
+                windowEnd: to,
+                windowDuration: to - from,
+                yMax: undefined,
+                yMin: undefined,
+            },
+            { type: 'SET_TRIGGER_START', triggerStartIndex: null },
+        ];
+        expect(store.getActions()).toEqual(expectedActions);
+    });
+
+    describe('Single trigger', () => {
+        const newIndex = 1005;
+        const store = mockStore({
+            app: {
+                ...initialState.app,
+                trigger: {
+                    ...initialState.app.trigger,
+                    triggerStartIndex: initialIndex,
+                    triggerSingleWaiting: true,
+                },
+            },
+        });
+
+        it('should reset single trigger and issue device stop samping command', () => {
+            store.dispatch(
+                processTriggerSample(5, mockPpk2Device, {
+                    ...samplingData,
+                    dataIndex: newIndex,
+                })
+            );
+            const from = indexToTimestamp(initialIndex);
+            const to = indexToTimestamp(newIndex);
+            const expectedActions = [
+                {
+                    type: 'TRIGGER_SINGLE_CLEAR',
+                },
+                {
+                    type: 'CHART_WINDOW',
+                    windowBegin: from,
+                    windowEnd: to,
+                    windowDuration: to - from,
+                    yMax: undefined,
+                    yMin: undefined,
+                },
+                { type: 'SET_TRIGGER_START', triggerStartIndex: null },
+            ];
+            expect(store.getActions()).toEqual(expectedActions);
+            expect(mockPpk2Device.ppkTriggerStop).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Buffer functionality', () => {
+        const store = mockStore({
+            app: {
+                ...initialState.app,
+                trigger: {
+                    ...initialState.app.trigger,
+                    triggerStartIndex: 1500,
+                },
+            },
+        });
+
+        it('Should handle the buffer wrapping around', () => {
+            // window size here will be 1000, so it should start drawing at index 500
+            store.dispatch(
+                processTriggerSample(5, mockPpk2Device, {
+                    ...samplingData,
+                    dataIndex: 499,
+                })
+            );
+            expect(store.getActions().length).toBe(0);
+            store.dispatch(
+                processTriggerSample(5, mockPpk2Device, {
+                    ...samplingData,
+                    dataIndex: 500,
+                })
+            );
+            expect(store.getActions().length).toBe(2);
+        });
+    });
+});

--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -233,6 +233,7 @@ export function open(deviceInfo) {
                 app: { samplingRunning },
                 dataLogger: { maxSampleFreq, sampleFreq },
             } = getState().app;
+            const { currentPane } = getState().appLayout;
 
             let zeroCappedValue = zeroCap(value);
 
@@ -262,7 +263,7 @@ export function open(deviceInfo) {
                 options.index = 0;
             }
 
-            if (!samplingRunning) {
+            if (isScopePane(currentPane) && !samplingRunning) {
                 dispatch(
                     processTriggerSample(value, device, {
                         samplingTime: options.samplingTime,

--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -67,20 +67,15 @@ import {
 import { updateRegulatorAction } from '../reducers/voltageRegulatorReducer';
 import { resistorsResetAction } from '../reducers/resistorCalibrationReducer';
 import {
-    chartWindowAction,
     animationAction,
     updateHasDigitalChannels,
     resetCursorAndChart,
 } from '../reducers/chartReducer';
 import { setSamplingAttrsAction } from '../reducers/dataLoggerReducer';
-import {
-    options,
-    bufferLengthInSeconds,
-    updateTitle,
-    indexToTimestamp,
-} from '../globals';
+import { options, updateTitle } from '../globals';
 import { updateGainsAction } from '../reducers/gainsReducer';
 import { isScopePane } from '../utils/panes';
+import { processTriggerSample } from './triggerActions';
 
 let device = null;
 let updateRequestInterval;
@@ -224,11 +219,11 @@ export function open(deviceInfo) {
             await dispatch(close());
         }
 
-        let isTrigger = 0;
         let prevValue = 0;
         let nbSamples = 0;
         let nbSamplesTotal = 0;
-        const onSample = ({ value, bits, timestamp }) => {
+
+        const onSample = ({ value, bits }) => {
             // PPK1 always sets timestamp, while PPK2 never does
             if (options.timestamp === undefined) {
                 options.timestamp = 0;
@@ -236,8 +231,6 @@ export function open(deviceInfo) {
 
             const {
                 app: { samplingRunning },
-                trigger: { triggerSingleWaiting, triggerLevel, triggerLength },
-                chart: { windowBegin, windowEnd },
                 dataLogger: { maxSampleFreq, sampleFreq },
             } = getState().app;
 
@@ -270,52 +263,14 @@ export function open(deviceInfo) {
             }
 
             if (!samplingRunning) {
-                const numberOfSamplesIn5ms = 500;
-                const { preSamplingOn, postSamplingOn } = getState().app.chart;
-                let wnd = Math.floor(
-                    (triggerLength * 1000) / options.samplingTime
+                dispatch(
+                    processTriggerSample(value, device, {
+                        samplingTime: options.samplingTime,
+                        dataIndex: options.index,
+                        dataBuffer: options.data,
+                    })
                 );
-                if (postSamplingOn) wnd += numberOfSamplesIn5ms;
-                if (!isTrigger) {
-                    if (
-                        timestamp !== undefined ||
-                        (value >= triggerLevel && prevValue < triggerLevel)
-                    ) {
-                        isTrigger = 1;
-                        if (triggerSingleWaiting) {
-                            logger.info('Trigger received, stopped waiting');
-                            dispatch(clearSingleTriggerWaitingAction());
-                            if (timestamp === undefined) {
-                                device.ppkTriggerStop();
-                            }
-                        }
-                    }
-                } else {
-                    isTrigger += 1;
-                }
-                if (isTrigger >= wnd) {
-                    isTrigger = 0;
-                    const startIndex = preSamplingOn
-                        ? options.index - numberOfSamplesIn5ms
-                        : options.index;
-
-                    const triggerBeginIndex =
-                        (startIndex - wnd + options.data.length) %
-                        options.data.length;
-                    const from = indexToTimestamp(triggerBeginIndex);
-                    const to = options.timestamp;
-                    dispatch(chartWindowAction(from, to, to - from));
-                }
             }
-
-            if (
-                (windowBegin !== 0 || windowEnd !== 0) &&
-                options.timestamp >= windowBegin + bufferLengthInSeconds * 1e6
-            ) {
-                // stop average when reaches end of buffer (i.e. would overwrite chart data)
-                dispatch(samplingStop());
-            }
-            prevValue = zeroCappedValue;
         };
 
         try {

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -1,0 +1,107 @@
+/* Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { logger } from 'nrfconnect/core';
+import { indexToTimestamp } from '../globals';
+import { chartWindowAction } from '../reducers/chartReducer';
+import {
+    clearSingleTriggerWaitingAction,
+    setTriggerStartAction,
+} from '../reducers/triggerReducer';
+
+export function processTriggerSample(currentValue, device, samplingData) {
+    return (dispatch, getState) => {
+        const {
+            samplingTime,
+            dataIndex: currentIndex,
+            dataBuffer,
+        } = samplingData;
+        const {
+            chart: { preSamplingOn, postSamplingOn },
+            trigger: {
+                triggerLength,
+                triggerLevel,
+                triggerSingleWaiting,
+                triggerStartIndex,
+            },
+        } = getState().app;
+
+        if (!triggerStartIndex) {
+            if (currentValue >= triggerLevel) {
+                dispatch(setTriggerStartAction(currentIndex));
+            }
+            return;
+        }
+
+        const windowSize = calculateWindowSize(
+            triggerLength,
+            samplingTime,
+            postSamplingOn,
+            device.numberOfSamplesIn5Ms
+        );
+
+        const enoughSamplesCollected =
+            (triggerStartIndex + windowSize) % dataBuffer.length <=
+            currentIndex;
+
+        if (enoughSamplesCollected) {
+            if (triggerSingleWaiting) {
+                logger.info('Trigger received, stopped waiting');
+                dispatch(clearSingleTriggerWaitingAction());
+                device.ppkTriggerStop();
+            }
+
+            const startIndex = preSamplingOn
+                ? triggerStartIndex - device.numberOfSamplesIn5Ms
+                : triggerStartIndex;
+            const from = indexToTimestamp(startIndex);
+            const to = indexToTimestamp(currentIndex);
+            dispatch(chartWindowAction(from, to, to - from));
+            dispatch(setTriggerStartAction(null));
+        }
+    };
+}
+
+export function calculateWindowSize(
+    triggerLength,
+    samplingTime,
+    postSamplingOn,
+    samplesToAdd
+) {
+    let windowSize = Math.floor((triggerLength * 1000) / samplingTime);
+    if (postSamplingOn) windowSize += samplesToAdd;
+    return windowSize;
+}

--- a/src/device/serialDevice.js
+++ b/src/device/serialDevice.js
@@ -73,6 +73,8 @@ class SerialDevice extends Device {
 
     isRunningInitially = false;
 
+    numberOfSamplesIn5Ms = 500;
+
     constructor(deviceInfo) {
         super();
 

--- a/src/globals.js
+++ b/src/globals.js
@@ -64,6 +64,3 @@ export const updateTitle = info => {
         .getCurrentWindow()
         .setTitle(`${title}${info ? ':' : ''} ${info || ''}`);
 };
-
-export const SCOPE_PANE = 0;
-export const DATA_LOGGER_PANE = 1;

--- a/src/reducers/triggerReducer.js
+++ b/src/reducers/triggerReducer.js
@@ -44,6 +44,7 @@ const initialState = {
         min: (450 * 13) / 1e3,
         max: (4000 * 13) / 1e3,
     },
+    triggerStartIndex: null,
 };
 
 export const EXTERNAL_TRIGGER_TOGGLE = 'EXTERNAL_TRIGGER_TOGGLE';
@@ -53,6 +54,7 @@ export const TRIGGER_TOGGLE = 'TRIGGER_TOGGLE';
 export const TRIGGER_LEVEL_SET = 'TRIGGER_LEVEL_SET';
 export const TRIGGER_LENGTH_SET = 'TRIGGER_LENGTH_SET';
 export const TRIGGER_WINDOW_RANGE = 'TRIGGER_WINDOW_RANGE';
+export const SET_TRIGGER_START = 'SET_TRIGGER_START';
 
 export const triggerLevelSetAction = triggerLevel => ({
     type: TRIGGER_LEVEL_SET,
@@ -67,6 +69,11 @@ export const triggerLengthSetAction = triggerLength => ({
 export const toggleTriggerAction = triggerRunning => ({
     type: TRIGGER_TOGGLE,
     triggerRunning,
+});
+
+export const setTriggerStartAction = triggerStartIndex => ({
+    type: SET_TRIGGER_START,
+    triggerStartIndex,
 });
 
 export const triggerSingleSetAction = () => ({ type: TRIGGER_SINGLE_SET });
@@ -124,7 +131,11 @@ export default (state = initialState, { type, ...action }) => {
                 triggerSingleWaiting,
             };
         }
-
+        case SET_TRIGGER_START:
+            return {
+                ...state,
+                triggerStartIndex: action.triggerStartIndex,
+            };
         case TRIGGER_LEVEL_SET:
         case TRIGGER_LENGTH_SET:
         case TRIGGER_WINDOW_RANGE: {


### PR DESCRIPTION
This pull request will extract trigger functionality from device actions into a new function which should be more or less pure. The idea is that this will increase readability, but perhaps even more important make it easier to test, because this functionality is important. The structure of the code has changed somewhat, i.e. we no longer keep a trigger-counter in the parent scope, instead we store the starting index (the index of the sample that caused the trigger) in the Redux store and then we calculate for each subsequent sample to see if we have reached the window size.

Timestamp has been removed, as there was no apparent difference in using it or not, but this has to be approved by someone who has more intimate knowledge of the app, such as @bencefr.

We also add tests for the most important trigger functionality in this pull request, such as:

- Verify that when trigger level is initially reached, we start collecting samples for charting
- When number of samples collected is equal to the window size, we dispatch an action to update the chart
- Single-triggering stops sampling when trigger is hit
- When the end of the ring buffer is reached, we start over from index 0.
- Pre- and post-sampling adds 500 samples to the start or end of the window respectively.