### PR TITLE
Ensure that sampling attributes are correctly set before they are used

### DIFF
--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -72,6 +72,7 @@ import {
     updateHasDigitalChannels,
     resetCursorAndChart,
 } from '../reducers/chartReducer';
+import { setSamplingAttrsAction } from '../reducers/dataLoggerReducer';
 import {
     options,
     bufferLengthInSeconds,
@@ -319,6 +320,11 @@ export function open(deviceInfo) {
 
         try {
             device = new Device(deviceInfo, onSample);
+            dispatch(
+                setSamplingAttrsAction(
+                    device.capabilities.maxContinuousSamplingTimeUs
+                )
+            );
             dispatch(setupOptions());
             dispatch(setDeviceRunningAction(device.isRunningInitially));
             const metadata = device.parseMeta(await device.start());

--- a/src/reducers/dataLoggerReducer.js
+++ b/src/reducers/dataLoggerReducer.js
@@ -57,6 +57,7 @@ const initialState = {
 
 const DL_SAMPLE_FREQ_LOG_10 = 'DL_SAMPLE_FREQ_LOG_10';
 const DL_DURATION_SECONDS = 'DL_DURATION_SECONDS';
+const SET_SAMPLING_ATTRS = 'SET_SAMPLING_ATTRS';
 
 export const updateSampleFreqLog10 = sampleFreqLog10 => ({
     type: DL_SAMPLE_FREQ_LOG_10,
@@ -69,11 +70,17 @@ export const updateDurationSeconds = durationSeconds => ({
     durationSeconds,
 });
 
+export const setSamplingAttrsAction = maxContinuousSamplingTimeUs => ({
+    type: SET_SAMPLING_ATTRS,
+    payload: {
+        maxContinuousSamplingTimeUs,
+    },
+});
+
 export default (state = initialState, { type, ...action }) => {
     switch (type) {
-        case 'DEVICE_OPENED': {
-            const samplingTime =
-                action.capabilities.maxContinuousSamplingTimeUs;
+        case SET_SAMPLING_ATTRS: {
+            const samplingTime = action.payload.maxContinuousSamplingTimeUs;
             const sampleFreq = Math.round(10000 / samplingTime) * 100;
             const maxFreqLog10 = Math.ceil(Math.log10(sampleFreq));
             return {

--- a/src/reducers/dataLoggerReducer.js
+++ b/src/reducers/dataLoggerReducer.js
@@ -72,15 +72,13 @@ export const updateDurationSeconds = durationSeconds => ({
 
 export const setSamplingAttrsAction = maxContinuousSamplingTimeUs => ({
     type: SET_SAMPLING_ATTRS,
-    payload: {
-        maxContinuousSamplingTimeUs,
-    },
+    maxContinuousSamplingTimeUs,
 });
 
 export default (state = initialState, { type, ...action }) => {
     switch (type) {
         case SET_SAMPLING_ATTRS: {
-            const samplingTime = action.payload.maxContinuousSamplingTimeUs;
+            const samplingTime = action.maxContinuousSamplingTimeUs;
             const sampleFreq = Math.round(10000 / samplingTime) * 100;
             const maxFreqLog10 = Math.ceil(Math.log10(sampleFreq));
             return {


### PR DESCRIPTION
Currently the order of operations was off, so we ended up using the default sampling frequency for PPK2 for PPK1 which messed up the timestamp. 

Another side-effect of this was swapping devices (e.g. PPK1 to PPK2) would end up using the sampling frequency of the previous device, again causing timestamp issues.