### PR TITLE
Adapt 3.0 to launcher 3.6.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 3.0.3
+## Fixed
+- Small visual glitch when used with nRF Connect for Desktop 3.6.1: The top margin in the side panel was shrunken
+
 ## Version 3.0.2
 ## Fixed
 - The CSV export was exporting the wrong portion of data #123

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ppk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Power Profiler",
   "displayName": "Power Profiler",
   "repository": {
@@ -10,7 +10,7 @@
   "author": "Nordic Semiconductor ASA",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "nrfconnect": "^3.6.0"
+    "nrfconnect": "^3.6.1"
   },
   "main": "dist/bundle.js",
   "files": [

--- a/src/components/SidePanel/sidepanel.scss
+++ b/src/components/SidePanel/sidepanel.scss
@@ -6,7 +6,7 @@
 
 .sidepanel {
     font-size: 12px;
-    padding: 8px 0;
+    padding: 32px 0 8px;
     min-height: 100%;
 
     .form-label, .form-group {


### PR DESCRIPTION
In 3.6.1 of the launcher the sidepanel top margin was shrunken. This takes that into account.