### PR TITLE
Feature/presample slider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ppk",
-  "version": "3.1.0-alpha.0",
+  "version": "3.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/actions/__tests__/triggerActions-test.js
+++ b/src/actions/__tests__/triggerActions-test.js
@@ -50,11 +50,10 @@ jest.mock('nrfconnect/core', () => {
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
-const mockPpk2Device = {
-    numberOfSamplesIn5Ms: 500,
+const mockDevice = {
     ppkTriggerStop: jest.fn(),
     capabilities: {
-        prePostTriggering: true,
+        prePostTriggering: false,
     },
 };
 
@@ -71,9 +70,9 @@ const initialState = {
         },
     },
 };
-const initialIndex = 5;
+const beginIndex = 5;
 const samplingData = {
-    dataIndex: initialIndex,
+    dataIndex: beginIndex,
     samplingTime: 10,
     dataBuffer: new Array(2000).fill(100),
 };
@@ -91,9 +90,9 @@ describe('Handle trigger', () => {
 
     it('should set triggerStart if value is higher than trigger level', () => {
         const store = mockStore(initialState);
-        store.dispatch(processTriggerSample(15, mockPpk2Device, samplingData));
+        store.dispatch(processTriggerSample(15, mockDevice, samplingData));
         const expectedActions = [
-            { type: 'SET_TRIGGER_START', triggerStartIndex: initialIndex },
+            { type: 'SET_TRIGGER_START', triggerStartIndex: beginIndex },
         ];
         expect(store.getActions()).toEqual(expectedActions);
     });
@@ -105,30 +104,22 @@ describe('Handle trigger', () => {
                 ...initialState.app,
                 trigger: {
                     ...initialState.app.trigger,
-                    triggerStartIndex: initialIndex,
+                    triggerStartIndex: beginIndex,
                 },
             },
         });
         store.dispatch(
-            processTriggerSample(5, mockPpk2Device, {
+            processTriggerSample(5, mockDevice, {
                 ...samplingData,
                 dataIndex: newIndex,
             })
         );
-        const from = indexToTimestamp(initialIndex);
-        const to = indexToTimestamp(newIndex);
-        const expectedActions = [
-            {
-                type: 'CHART_WINDOW',
-                windowBegin: from,
-                windowEnd: to,
-                windowDuration: to - from,
-                yMax: undefined,
-                yMin: undefined,
-            },
-            { type: 'SET_TRIGGER_START', triggerStartIndex: null },
-        ];
-        expect(store.getActions()).toEqual(expectedActions);
+        expect(store.getActions()).toEqual(
+            getExpectedChartActions(
+                indexToTimestamp(beginIndex),
+                indexToTimestamp(newIndex)
+            )
+        );
     });
 
     describe('Single trigger', () => {
@@ -138,7 +129,7 @@ describe('Handle trigger', () => {
                 ...initialState.app,
                 trigger: {
                     ...initialState.app.trigger,
-                    triggerStartIndex: initialIndex,
+                    triggerStartIndex: beginIndex,
                     triggerSingleWaiting: true,
                 },
             },
@@ -146,29 +137,21 @@ describe('Handle trigger', () => {
 
         it('should reset single trigger and issue device stop samping command', () => {
             store.dispatch(
-                processTriggerSample(5, mockPpk2Device, {
+                processTriggerSample(5, mockDevice, {
                     ...samplingData,
                     dataIndex: newIndex,
                 })
             );
-            const from = indexToTimestamp(initialIndex);
-            const to = indexToTimestamp(newIndex);
-            const expectedActions = [
+            expect(store.getActions()).toEqual([
                 {
                     type: 'TRIGGER_SINGLE_CLEAR',
                 },
-                {
-                    type: 'CHART_WINDOW',
-                    windowBegin: from,
-                    windowEnd: to,
-                    windowDuration: to - from,
-                    yMax: undefined,
-                    yMin: undefined,
-                },
-                { type: 'SET_TRIGGER_START', triggerStartIndex: null },
-            ];
-            expect(store.getActions()).toEqual(expectedActions);
-            expect(mockPpk2Device.ppkTriggerStop).toHaveBeenCalledTimes(1);
+                ...getExpectedChartActions(
+                    indexToTimestamp(beginIndex),
+                    indexToTimestamp(newIndex)
+                ),
+            ]);
+            expect(mockDevice.ppkTriggerStop).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -186,14 +169,14 @@ describe('Handle trigger', () => {
         it('Should handle the buffer wrapping around', () => {
             // window size here will be 1000, so it should start drawing at index 500
             store.dispatch(
-                processTriggerSample(5, mockPpk2Device, {
+                processTriggerSample(5, mockDevice, {
                     ...samplingData,
                     dataIndex: 499,
                 })
             );
             expect(store.getActions().length).toBe(0);
             store.dispatch(
-                processTriggerSample(5, mockPpk2Device, {
+                processTriggerSample(5, mockDevice, {
                     ...samplingData,
                     dataIndex: 500,
                 })
@@ -201,4 +184,93 @@ describe('Handle trigger', () => {
             expect(store.getActions().length).toBe(2);
         });
     });
+
+    describe('Window offset', () => {
+        const mockDeviceWithSamplingCapabilities = {
+            ...mockDevice,
+            capabilities: {
+                ...mockDevice.capabilities,
+                prePostTriggering: true,
+            },
+        };
+        const endIndex = beginIndex + 1000;
+        const windowSize = calculateWindowSize(
+            defaultTriggerLength,
+            samplingData.samplingTime
+        );
+
+        it('should by default shift window by half the window size for given hw', () => {
+            const store = mockStore({
+                app: {
+                    ...initialState.app,
+                    trigger: {
+                        ...initialState.app.trigger,
+                        triggerStartIndex: beginIndex,
+                    },
+                },
+            });
+            store.dispatch(
+                processTriggerSample(5, mockDeviceWithSamplingCapabilities, {
+                    ...samplingData,
+                    dataIndex: endIndex,
+                })
+            );
+            const expectedShiftedIndex = windowSize / 2;
+            expect(expectedShiftedIndex).toBe(500);
+            const from = indexToTimestamp(beginIndex - expectedShiftedIndex);
+            const to = indexToTimestamp(endIndex - expectedShiftedIndex);
+            expect(store.getActions()).toEqual(
+                getExpectedChartActions(from, to)
+            );
+        });
+
+        it('should shift window according to given offset', () => {
+            const triggerWindowOffset = 500;
+            const store = mockStore({
+                app: {
+                    ...initialState.app,
+                    trigger: {
+                        ...initialState.app.trigger,
+                        triggerStartIndex: beginIndex,
+                        triggerWindowOffset,
+                    },
+                },
+            });
+            store.dispatch(
+                processTriggerSample(5, mockDeviceWithSamplingCapabilities, {
+                    ...samplingData,
+                    dataIndex: endIndex,
+                })
+            );
+
+            // triggerWindowOffset = 500 translates to 50 samples offset with a samplingTime of 10
+            // Currently the implementation is such that triggerWindowOffset === -windowSize / 2
+            // shifts the window all the way to the left, while triggerWindowOffset === windowSize / 2
+            // shifts the window all the way to the right.
+            //
+            // For PPK2, default trigger position inside window should be center, e.g. it will be shifted
+            // by half the size of the window plus the given offset.
+            const shift = triggerWindowOffset / samplingData.samplingTime;
+            const expectedShiftedIndex = windowSize / 2 + shift;
+            expect(shift).toBe(50);
+            expect(expectedShiftedIndex).toBe(550);
+            const from = indexToTimestamp(beginIndex - expectedShiftedIndex);
+            const to = indexToTimestamp(endIndex - expectedShiftedIndex);
+            expect(store.getActions()).toEqual(
+                getExpectedChartActions(from, to)
+            );
+        });
+    });
 });
+
+const getExpectedChartActions = (from, to) => [
+    {
+        type: 'CHART_WINDOW',
+        windowBegin: from,
+        windowEnd: to,
+        windowDuration: to - from,
+        yMax: undefined,
+        yMin: undefined,
+    },
+    { type: 'SET_TRIGGER_START', triggerStartIndex: null },
+];

--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -500,12 +500,11 @@ export function switchingPointsReset() {
     };
 }
 
-export function updateTriggerLevel(level) {
+export function updateTriggerLevel(triggerLevel) {
     return async (dispatch, getState) => {
-        const triggerLevel = Math.round(Math.min(1000000, Math.max(0, level)));
-        const { triggerSingleWaiting, triggerRunning } = getState().app.trigger;
         dispatch(triggerLevelSetAction(triggerLevel));
 
+        const { triggerSingleWaiting, triggerRunning } = getState().app.trigger;
         const high = (triggerLevel >> 16) & 0xff;
         const mid = (triggerLevel >> 8) & 0xff;
         const low = triggerLevel & 0xff;

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -80,9 +80,9 @@ export function processTriggerSample(currentValue, device, samplingData) {
         }
 
         const shiftedIndex = getShiftedIndex(
-            device.capabilities.prePostTriggering,
             windowSize,
-            triggerWindowOffset
+            triggerWindowOffset,
+            device.capabilities.prePostTriggering
         );
 
         const from = indexToTimestamp(triggerStartIndex + shiftedIndex);
@@ -92,8 +92,13 @@ export function processTriggerSample(currentValue, device, samplingData) {
     };
 }
 
-function getShiftedIndex(supportsPrePostTriggering, windowSize, triggerOffset) {
+function getShiftedIndex(
+    windowSize,
+    triggerOffset = 0,
+    supportsPrePostTriggering = false
+) {
     if (!supportsPrePostTriggering) return 0;
+    if (triggerOffset === 0) return 0;
     const offsetToSamples = Math.ceil(triggerOffset / 10);
     return -windowSize / 2 - offsetToSamples;
 }

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -81,28 +81,29 @@ export function processTriggerSample(currentValue, device, samplingData) {
 
         const shiftedIndex = getShiftedIndex(
             windowSize,
+            samplingTime,
             triggerWindowOffset,
             device.capabilities.prePostTriggering
         );
 
-        const from = indexToTimestamp(triggerStartIndex + shiftedIndex);
-        const to = indexToTimestamp(currentIndex + shiftedIndex);
+        const from = indexToTimestamp(triggerStartIndex - shiftedIndex);
+        const to = indexToTimestamp(currentIndex - shiftedIndex);
         dispatch(chartWindowAction(from, to, to - from));
         dispatch(setTriggerStartAction(null));
     };
 }
 
+// PPK2 trigger point should by default be shifted to middle of window
 function getShiftedIndex(
     windowSize,
+    samplingTime,
     triggerOffset = 0,
     supportsPrePostTriggering = false
 ) {
     if (!supportsPrePostTriggering) return 0;
-    if (triggerOffset === 0) return 0;
-    const offsetToSamples = Math.ceil(triggerOffset / 10);
-    return -windowSize / 2 - offsetToSamples;
+    const offsetToSamples = Math.ceil(triggerOffset / samplingTime);
+    return windowSize / 2 + offsetToSamples;
 }
 
-export function calculateWindowSize(triggerLength, samplingTime) {
-    return Math.floor((triggerLength * 1000) / samplingTime);
-}
+export const calculateWindowSize = (triggerLength, samplingTime) =>
+    Math.floor((triggerLength * 1000) / samplingTime);

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -42,6 +42,21 @@ import {
     setTriggerStartAction,
 } from '../reducers/triggerReducer';
 
+// PPK2 trigger point should by default be shifted to middle of window
+const getShiftedIndex = (
+    windowSize,
+    samplingTime,
+    triggerOffset = 0,
+    supportsPrePostTriggering = false
+) => {
+    if (!supportsPrePostTriggering) return 0;
+    const offsetToSamples = Math.ceil(triggerOffset / samplingTime);
+    return windowSize / 2 + offsetToSamples;
+};
+
+export const calculateWindowSize = (triggerLength, samplingTime) =>
+    Math.floor((triggerLength * 1000) / samplingTime);
+
 export function processTriggerSample(currentValue, device, samplingData) {
     return (dispatch, getState) => {
         const {
@@ -92,18 +107,3 @@ export function processTriggerSample(currentValue, device, samplingData) {
         dispatch(setTriggerStartAction(null));
     };
 }
-
-// PPK2 trigger point should by default be shifted to middle of window
-function getShiftedIndex(
-    windowSize,
-    samplingTime,
-    triggerOffset = 0,
-    supportsPrePostTriggering = false
-) {
-    if (!supportsPrePostTriggering) return 0;
-    const offsetToSamples = Math.ceil(triggerOffset / samplingTime);
-    return windowSize / 2 + offsetToSamples;
-}
-
-export const calculateWindowSize = (triggerLength, samplingTime) =>
-    Math.floor((triggerLength * 1000) / samplingTime);

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -45,7 +45,8 @@ import Button from 'react-bootstrap/Button';
 
 import ChartTop from './ChartTop';
 import StatBox from './StatBox';
-import TimeSpan from './TimeSpan';
+import TimeSpanTop from './TimeSpan/TimeSpanTop';
+import TimeSpanBottom from './TimeSpan/TimeSpanBottom';
 import DigitalChannels from './DigitalChannels';
 import ChartContainer from './ChartContainer';
 
@@ -355,7 +356,7 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
                     zoomToWindow={zoomToWindow}
                     chartRef={chartRef}
                 />
-                <TimeSpan width={chartAreaWidth + 1} className="window" />
+                <TimeSpanTop width={chartAreaWidth + 1} />
                 <ChartContainer
                     setLen={setLen}
                     setChartAreaWidth={setChartAreaWidth}
@@ -365,11 +366,10 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
                     lineData={lineData}
                     mappedIndex={mappedIndex}
                 />
-                <TimeSpan
+                <TimeSpanBottom
                     cursorBegin={cursorBegin}
                     cursorEnd={cursorEnd}
                     width={chartAreaWidth + 1}
-                    className="selection"
                 />
                 <div
                     className="chart-bottom"

--- a/src/components/Chart/ChartContainer.jsx
+++ b/src/components/Chart/ChartContainer.jsx
@@ -39,7 +39,10 @@ import { Line } from 'react-chartjs-2';
 import { unit } from 'mathjs';
 import { useSelector, useDispatch } from 'react-redux';
 import { func, number, shape, arrayOf } from 'prop-types';
-import { triggerState } from '../../reducers/triggerReducer';
+import {
+    triggerState,
+    triggerLevelSetAction,
+} from '../../reducers/triggerReducer';
 
 import dragSelectPlugin from './plugins/chart.dragSelect';
 import zoomPanPlugin from './plugins/chart.zoomPan';
@@ -48,7 +51,7 @@ import triggerLevelPlugin from './plugins/chart.triggerLevel';
 
 import { appState } from '../../reducers/appReducer';
 import { chartState } from '../../reducers/chartReducer';
-import { updateTriggerLevel } from '../../actions/deviceActions';
+import { updateTriggerLevel as updateTriggerLevelAction } from '../../actions/deviceActions';
 import { yAxisWidthPx, rightMarginPx } from './chart.scss';
 import colors from '../colors.scss';
 import { isRealTimePane } from '../../utils/panes';
@@ -118,7 +121,8 @@ const ChartContainer = ({
         showGridLines,
     } = useSelector(chartState);
     const { samplingRunning } = useSelector(appState);
-    const sendTriggerLevel = level => dispatch(updateTriggerLevel(level));
+    const sendTriggerLevel = level => dispatch(updateTriggerLevelAction(level));
+    const updateTriggerLevel = level => dispatch(triggerLevelSetAction(level));
     const live =
         windowBegin === 0 &&
         windowEnd === 0 &&
@@ -210,6 +214,7 @@ const ChartContainer = ({
         triggerLevel,
         triggerActive: triggerRunning || triggerSingleWaiting,
         sendTriggerLevel,
+        updateTriggerLevel,
         snapping,
         live,
         triggerHandleVisible: isRealTimePane() && !externalTrigger,

--- a/src/components/Chart/ChartContainer.jsx
+++ b/src/components/Chart/ChartContainer.jsx
@@ -115,6 +115,7 @@ const ChartContainer = ({
         yMin,
         yMax,
         timestampsVisible,
+        showGridLines,
     } = useSelector(chartState);
     const { samplingRunning } = useSelector(appState);
     const sendTriggerLevel = level => dispatch(updateTriggerLevel(level));
@@ -167,7 +168,7 @@ const ChartContainer = ({
                         maxTicksLimit: 7,
                     },
                     gridLines: {
-                        display: true,
+                        display: showGridLines,
                         drawBorder: true,
                         drawOnChartArea: true,
                     },
@@ -189,7 +190,7 @@ const ChartContainer = ({
                         callback: uA => (uA < 0 ? '' : formatCurrent(uA)),
                     },
                     gridLines: {
-                        display: true,
+                        display: showGridLines,
                         drawBorder: true,
                         drawOnChartArea: true,
                     },
@@ -213,29 +214,32 @@ const ChartContainer = ({
         live,
         triggerHandleVisible: isRealTimePane() && !externalTrigger,
     };
+
+    const plugins = [
+        dragSelectPlugin,
+        zoomPanPlugin,
+        triggerLevelPlugin,
+        crossHairPlugin,
+        {
+            id: 'notifier',
+            afterLayout(chart) {
+                const { chartArea, width } = chart;
+                chartArea.right = width - rightMargin;
+                const { left, right } = chart.chartArea;
+                const w = Math.trunc(right - left);
+                setLen(Math.min(w, 2000));
+                setChartAreaWidth(w);
+            },
+        },
+    ];
+
     return (
         <div className="chart-container">
             <Line
                 ref={chartRef}
                 data={chartData}
                 options={chartOptions}
-                plugins={[
-                    dragSelectPlugin,
-                    zoomPanPlugin,
-                    triggerLevelPlugin,
-                    crossHairPlugin,
-                    {
-                        id: 'notifier',
-                        afterLayout(chart) {
-                            const { chartArea, width } = chart;
-                            chartArea.right = width - rightMargin;
-                            const { left, right } = chart.chartArea;
-                            const w = Math.trunc(right - left);
-                            setLen(Math.min(w, 2000));
-                            setChartAreaWidth(w);
-                        },
-                    },
-                ]}
+                plugins={plugins}
             />
         </div>
     );

--- a/src/components/Chart/TimeSpan/TimeSpanBottom.jsx
+++ b/src/components/Chart/TimeSpan/TimeSpanBottom.jsx
@@ -35,16 +35,16 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { number, string } from 'prop-types';
+import { number } from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
-import { unit } from 'mathjs';
-import { chartState, chartCursorAction } from '../../reducers/chartReducer';
+import { chartState, chartCursorAction } from '../../../reducers/chartReducer';
 
-import { options } from '../../globals';
+import { options } from '../../../globals';
+import TimeSpanLabel from './TimeSpanLabel';
 
 import './timespan.scss';
 
-const handle = (
+const handleSvg = (
     <g>
         <path d="M 0 24 C 0 25 1 26 2 26 L 9 26 C 10 26 11 25 11 24 L 11 11 C 11 7 5.5 0 5.5 0 C 5.5 0 0 7 0 11 z" />
         <line x1="3" y1="22" x2="8" y2="22" />
@@ -53,12 +53,7 @@ const handle = (
     </g>
 );
 
-const TimeSpan = ({
-    cursorBegin = null,
-    cursorEnd = null,
-    width,
-    className = '',
-}) => {
+const TimeSpanBottom = ({ cursorBegin = null, cursorEnd = null, width }) => {
     const dispatch = useDispatch();
     const chartCursor = useCallback(
         (...args) => dispatch(chartCursorAction(...args)),
@@ -71,20 +66,7 @@ const TimeSpan = ({
     const w1 = windowEnd || options.timestamp - options.samplingTime;
     const w0 = windowBegin || w1 - windowDuration;
 
-    const duration =
-        cursorBegin === null ? windowDuration : cursorEnd - cursorBegin;
-
-    let time = unit(duration, 'us');
-    if (duration > 60 * 1e6) {
-        time = time.to('min');
-    }
-    const v = time.format({ notation: 'fixed', precision: 2 });
-    const [valStr, unitStr] = v.split(' ');
-
     const showHandles = cursorBegin !== null && w0 !== 0;
-
-    const [begin, end] =
-        cursorBegin === null ? [w0, w1] : [cursorBegin, cursorEnd];
 
     const onPointerDown = ({ clientX, pointerId, target }) => {
         target.setPointerCapture(pointerId);
@@ -94,9 +76,8 @@ const TimeSpan = ({
         target.releasePointerCapture(pointerId);
         setDrag(null);
     };
-
     return (
-        <div className={`timespan ${className}`} style={{ width }}>
+        <div className="timespan selection" style={{ width }}>
             {showHandles && (
                 <div
                     className="cursor begin"
@@ -118,21 +99,11 @@ const TimeSpan = ({
                     onPointerUp={onPointerUp}
                 >
                     <svg height={26} width={11}>
-                        {handle}
+                        {handleSvg}
                     </svg>
                 </div>
             )}
-            <div
-                className="span"
-                style={{
-                    left: `${(100 * (begin - w0)) / windowDuration}%`,
-                    width: `${(100 * (end - begin)) / windowDuration}%`,
-                }}
-            >
-                <div className="value">
-                    {`\u0394${valStr}${unitStr.replace('u', '\u00B5')}`}
-                </div>
-            </div>
+            <TimeSpanLabel duration={windowDuration} />
             {showHandles && (
                 <div
                     className="cursor end"
@@ -154,7 +125,7 @@ const TimeSpan = ({
                     onPointerUp={onPointerUp}
                 >
                     <svg height={26} width={11}>
-                        {handle}
+                        {handleSvg}
                     </svg>
                 </div>
             )}
@@ -162,11 +133,10 @@ const TimeSpan = ({
     );
 };
 
-TimeSpan.propTypes = {
+TimeSpanBottom.propTypes = {
     cursorBegin: number,
     cursorEnd: number,
     width: number.isRequired,
-    className: string,
 };
 
-export default TimeSpan;
+export default TimeSpanBottom;

--- a/src/components/Chart/TimeSpan/TimeSpanLabel.jsx
+++ b/src/components/Chart/TimeSpan/TimeSpanLabel.jsx
@@ -35,58 +35,46 @@
  */
 
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { CollapsibleGroup } from 'pc-nrfconnect-shared';
-import { Toggle } from '../../from_pc-nrfconnect-shared';
+import { unit } from 'mathjs';
+import { number } from 'prop-types';
 
-import DigitalChannels from './DigitalChannels';
+const formatTime = duration => {
+    let time = unit(duration, 'us');
+    if (duration > 60 * 1e6) {
+        time = time.to('min');
+    }
+    const v = time.format({ notation: 'fixed', precision: 2 });
+    return v.split(' ');
+};
 
-import {
-    chartState,
-    toggleDigitalChannels,
-    toggleTimestamps,
-    toggleGridLines,
-} from '../../reducers/chartReducer';
-import { isDataLoggerPane, isRealTimePane } from '../../utils/panes';
+const TimeSpanLabel = ({ begin, end, duration, totalDuration = duration }) => {
+    const start = begin !== undefined ? (100 * begin) / totalDuration : 0;
+    const width =
+        begin !== undefined && end !== undefined
+            ? (100 * (end - begin)) / totalDuration
+            : 100;
 
-export default () => {
-    const dispatch = useDispatch();
-    const {
-        digitalChannelsVisible,
-        timestampsVisible,
-        hasDigitalChannels,
-        showGridLines,
-    } = useSelector(chartState);
+    const [valStr, unitStr] = formatTime(duration);
+    const label = `\u0394${valStr}${unitStr.replace('u', '\u00B5')}`;
 
     return (
-        <CollapsibleGroup heading="Display options" defaultCollapsed={false}>
-            <Toggle
-                onToggle={() => dispatch(toggleTimestamps())}
-                isToggled={timestampsVisible}
-                label="Timestamps"
-                variant="secondary"
-            />
-            {hasDigitalChannels && isDataLoggerPane() && (
-                <>
-                    <Toggle
-                        onToggle={() => dispatch(toggleDigitalChannels())}
-                        isToggled={digitalChannelsVisible}
-                        label="Digital channels"
-                        variant="secondary"
-                    />
-                    <DigitalChannels />
-                </>
-            )}
-            {isRealTimePane() && (
-                <>
-                    <Toggle
-                        onToggle={() => dispatch(toggleGridLines())}
-                        isToggled={showGridLines}
-                        label="Show grid"
-                        variant="secondary"
-                    />
-                </>
-            )}
-        </CollapsibleGroup>
+        <div
+            className="span"
+            style={{
+                left: `${start}%`,
+                width: `${width}%`,
+            }}
+        >
+            <div className="value">{label}</div>
+        </div>
     );
+};
+
+export default TimeSpanLabel;
+
+TimeSpanLabel.propTypes = {
+    duration: number.isRequired,
+    begin: number,
+    end: number,
+    totalDuration: number,
 };

--- a/src/components/Chart/TimeSpan/TimeSpanTop.jsx
+++ b/src/components/Chart/TimeSpan/TimeSpanTop.jsx
@@ -35,58 +35,61 @@
  */
 
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { CollapsibleGroup } from 'pc-nrfconnect-shared';
-import { Toggle } from '../../from_pc-nrfconnect-shared';
+import { useSelector } from 'react-redux';
+import { number } from 'prop-types';
+import { chartState } from '../../../reducers/chartReducer';
+import { triggerState } from '../../../reducers/triggerReducer';
+import { appState } from '../../../reducers/appReducer';
 
-import DigitalChannels from './DigitalChannels';
+import WindowOffsetSlider from './WindowOffsetSlider';
+import TimeSpanLabel from './TimeSpanLabel';
 
-import {
-    chartState,
-    toggleDigitalChannels,
-    toggleTimestamps,
-    toggleGridLines,
-} from '../../reducers/chartReducer';
-import { isDataLoggerPane, isRealTimePane } from '../../utils/panes';
+import './timespan.scss';
 
-export default () => {
-    const dispatch = useDispatch();
+const TimeSpanTop = ({ width }) => {
+    const { windowDuration } = useSelector(chartState);
+    const { triggerRunning, triggerWindowOffset } = useSelector(triggerState);
     const {
-        digitalChannelsVisible,
-        timestampsVisible,
-        hasDigitalChannels,
-        showGridLines,
-    } = useSelector(chartState);
+        capabilities: { prePostTriggering },
+    } = useSelector(appState);
+
+    const showHandle = prePostTriggering && triggerRunning;
+    const distanceFromOriginToTriggerHandle = showHandle
+        ? triggerWindowOffset + windowDuration / 2
+        : null;
 
     return (
-        <CollapsibleGroup heading="Display options" defaultCollapsed={false}>
-            <Toggle
-                onToggle={() => dispatch(toggleTimestamps())}
-                isToggled={timestampsVisible}
-                label="Timestamps"
-                variant="secondary"
-            />
-            {hasDigitalChannels && isDataLoggerPane() && (
+        <div className="timespan window" style={{ width }}>
+            {showHandle ? (
                 <>
-                    <Toggle
-                        onToggle={() => dispatch(toggleDigitalChannels())}
-                        isToggled={digitalChannelsVisible}
-                        label="Digital channels"
-                        variant="secondary"
+                    <TimeSpanLabel
+                        begin={0}
+                        end={distanceFromOriginToTriggerHandle}
+                        duration={distanceFromOriginToTriggerHandle}
+                        totalDuration={windowDuration}
                     />
-                    <DigitalChannels />
-                </>
-            )}
-            {isRealTimePane() && (
-                <>
-                    <Toggle
-                        onToggle={() => dispatch(toggleGridLines())}
-                        isToggled={showGridLines}
-                        label="Show grid"
-                        variant="secondary"
+                    <WindowOffsetSlider
+                        triggerWindowOffset={triggerWindowOffset}
+                        duration={windowDuration}
+                    />
+                    <TimeSpanLabel
+                        begin={distanceFromOriginToTriggerHandle}
+                        end={windowDuration}
+                        duration={
+                            windowDuration - distanceFromOriginToTriggerHandle
+                        }
+                        totalDuration={windowDuration}
                     />
                 </>
+            ) : (
+                <TimeSpanLabel duration={windowDuration} />
             )}
-        </CollapsibleGroup>
+        </div>
     );
+};
+
+export default TimeSpanTop;
+
+TimeSpanTop.propTypes = {
+    width: number,
 };

--- a/src/components/Chart/TimeSpan/WindowOffsetSlider.jsx
+++ b/src/components/Chart/TimeSpan/WindowOffsetSlider.jsx
@@ -42,9 +42,9 @@ import { setWindowOffsetAction } from '../../../reducers/triggerReducer';
 import './timespan.scss';
 
 const windowOffsetHandleSvg = (
-    <g>
+    <svg height={24} width={10}>
         <path d="M 0 24 C 0 25 1 26 2 26 L 9 26 C 10 26 11 25 11 24 L 11 11 C 11 7 5.5 0 5.5 0 C 5.5 0 0 7 0 11 z" />
-    </g>
+    </svg>
 );
 
 const WindowOffsetSlider = ({ triggerWindowOffset, duration }) => {
@@ -88,9 +88,7 @@ const WindowOffsetSlider = ({ triggerWindowOffset, duration }) => {
             onPointerUp={onPointerUp}
             data-testid="offsetHandler"
         >
-            <svg height={24} width={10}>
-                {windowOffsetHandleSvg}
-            </svg>
+            {windowOffsetHandleSvg}
         </div>
     );
 };

--- a/src/components/Chart/TimeSpan/WindowOffsetSlider.jsx
+++ b/src/components/Chart/TimeSpan/WindowOffsetSlider.jsx
@@ -87,6 +87,7 @@ const WindowOffsetSlider = ({ triggerWindowOffset, duration }) => {
             onPointerMove={onPointerMove}
             onPointerUp={onPointerUp}
             data-testid="offsetHandler"
+            title="Slide right or left handle to shift window placement"
         >
             {windowOffsetHandleSvg}
         </div>

--- a/src/components/Chart/TimeSpan/WindowOffsetSlider.jsx
+++ b/src/components/Chart/TimeSpan/WindowOffsetSlider.jsx
@@ -86,6 +86,7 @@ const WindowOffsetSlider = ({ triggerWindowOffset, duration }) => {
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onPointerUp={onPointerUp}
+            data-testid="offsetHandler"
         >
             <svg height={24} width={10}>
                 {windowOffsetHandleSvg}

--- a/src/components/Chart/TimeSpan/timespan.scss
+++ b/src/components/Chart/TimeSpan/timespan.scss
@@ -1,16 +1,22 @@
-@import "~pc-nrfconnect-shared/src/variables";
-@import "./chart.scss";
+@import '~pc-nrfconnect-shared/src/variables';
+@import './../chart.scss';
 
 .timespan {
     margin-left: $yAxisWidthPx;
     height: 1rem;
     position: relative;
-    overflow: hidden;
 
     &.selection {
         height: 26px;
         margin-top: -10px;
         padding-top: 10px;
+        overflow: 'hidden';
+    }
+
+    &.offset {
+        height: 26px;
+        margin-top: -10px;
+        overflow: initial !important;
     }
 
     .span {
@@ -57,6 +63,13 @@
         line {
             stroke-width: 1;
             stroke: $gray-50;
+        }
+    }
+
+    .triggerOffset {
+        svg {
+            fill: $nordic-blue;
+            transform: rotate(180deg);
         }
     }
 }

--- a/src/components/Chart/plugins/chart.triggerLevel.js
+++ b/src/components/Chart/plugins/chart.triggerLevel.js
@@ -38,7 +38,10 @@
 
 import colors from '../../colors.scss';
 
-const { gray700: color, white, nordicBlue } = colors;
+const { gray700: color, nordicBlue } = colors;
+
+const getTriggerLevelFromCoordinate = coordinate =>
+    Math.round(Math.min(1000000, Math.max(0, coordinate)));
 
 const plugin = {
     id: 'triggerLevel',
@@ -93,13 +96,25 @@ const plugin = {
         chartInstance.triggerLine.y = evt.layerY;
         const {
             scales: { yScale },
-            options: { sendTriggerLevel },
+            options: { updateTriggerLevel },
         } = chartInstance;
-        sendTriggerLevel(yScale.getValueForPixel(chartInstance.triggerLine.y));
+        const level = getTriggerLevelFromCoordinate(
+            yScale.getValueForPixel(chartInstance.triggerLine.y)
+        );
+        updateTriggerLevel(level);
     },
 
     pointerLeaveHandler(chartInstance) {
-        if (!chartInstance.triggerLine) return;
+        if (chartInstance.triggerLine.y !== null) {
+            const {
+                scales: { yScale },
+                options: { sendTriggerLevel },
+            } = chartInstance;
+            const level = getTriggerLevelFromCoordinate(
+                yScale.getValueForPixel(chartInstance.triggerLine.y)
+            );
+            sendTriggerLevel(level);
+        }
         chartInstance.triggerLine.y = null;
     },
 
@@ -124,7 +139,6 @@ const plugin = {
         const {
             chartArea: { left, right },
             chart: { ctx },
-            options: { formatY, triggerLevel },
         } = chartInstance;
 
         const coords = this.getCoords(chartInstance);

--- a/src/components/Chart/plugins/chart.triggerLevel.js
+++ b/src/components/Chart/plugins/chart.triggerLevel.js
@@ -38,7 +38,7 @@
 
 import colors from '../../colors.scss';
 
-const { gray700: color, white } = colors;
+const { gray700: color, white, nordicBlue } = colors;
 
 const plugin = {
     id: 'triggerLevel',
@@ -59,13 +59,15 @@ const plugin = {
         if (y < top || y > bottom) {
             return null;
         }
+        const width = 24;
+        const height = 10;
         return {
             y: Math.ceil(y - 0.5) + 0.5,
             label: {
-                x: left - 62,
-                y: y - 9.5,
-                w: 80,
-                h: 18,
+                x: left - width,
+                y: y - height / 2 - 0.5,
+                w: width,
+                h: height,
             },
         };
     },
@@ -89,19 +91,15 @@ const plugin = {
         const { label } = this.getCoords(chartInstance) || {};
         if (!label) return;
         chartInstance.triggerLine.y = evt.layerY;
+        const {
+            scales: { yScale },
+            options: { sendTriggerLevel },
+        } = chartInstance;
+        sendTriggerLevel(yScale.getValueForPixel(chartInstance.triggerLine.y));
     },
 
     pointerLeaveHandler(chartInstance) {
         if (!chartInstance.triggerLine) return;
-        if (chartInstance.triggerLine.y !== null) {
-            const {
-                scales: { yScale },
-                options: { sendTriggerLevel },
-            } = chartInstance;
-            sendTriggerLevel(
-                yScale.getValueForPixel(chartInstance.triggerLine.y)
-            );
-        }
         chartInstance.triggerLine.y = null;
     },
 
@@ -135,59 +133,82 @@ const plugin = {
         const { y, label } = coords;
 
         ctx.save();
-        ctx.lineWidth = 0.5;
-        ctx.strokeStyle = color;
-        ctx.setLineDash([4, 5]);
-        ctx.beginPath();
-        ctx.moveTo(left, y);
-        ctx.lineTo(right, y);
-        ctx.closePath();
-        ctx.stroke();
-        ctx.setLineDash([]);
 
-        ctx.fillStyle = color;
+        function drawDashedLine() {
+            ctx.lineWidth = 0.5;
+            ctx.strokeStyle = color;
+            ctx.setLineDash([4, 5]);
+            ctx.beginPath();
+            ctx.moveTo(left, y - 1); // Moving it 1px up seems to center it on the label
+            ctx.lineTo(right, y - 1); // Moving it 1px up seems to center it on the label
+            ctx.closePath();
+            ctx.stroke();
+            ctx.setLineDash([]);
+        }
 
-        ctx.translate(label.x, label.y);
-        ctx.beginPath();
-        ctx.moveTo(0, 2);
-        ctx.bezierCurveTo(0, 1, 1, 0, 2, 0);
-        ctx.lineTo(label.w - 20, 0);
-        ctx.bezierCurveTo(
-            label.w - 15,
-            0,
-            label.w,
-            label.h / 2,
-            label.w,
-            label.h / 2
-        );
-        ctx.bezierCurveTo(
-            label.w,
-            label.h / 2,
-            label.w - 15,
-            label.h,
-            label.w - 20,
-            label.h
-        );
-        ctx.lineTo(2, label.h);
-        ctx.bezierCurveTo(1, label.h, 0, label.h - 1, 0, label.h - 2);
-        ctx.closePath();
-        ctx.fill();
+        function drawHandle() {
+            ctx.fillStyle = nordicBlue;
 
-        ctx.lineWidth = 1;
-        ctx.strokeStyle = colors.gray50;
-        ctx.beginPath();
-        ctx.moveTo(4, 3);
-        ctx.lineTo(4, label.h - 3);
-        ctx.moveTo(8, 3);
-        ctx.lineTo(8, label.h - 3);
-        ctx.moveTo(12, 3);
-        ctx.lineTo(12, label.h - 3);
-        ctx.closePath();
-        ctx.stroke();
+            ctx.translate(label.x, label.y);
+            ctx.beginPath();
+            ctx.moveTo(0, 2);
+            ctx.bezierCurveTo(0, 1, 1, 0, 2, 0);
+            const curveStart = label.w - 8;
+            ctx.lineTo(curveStart, 0);
+            ctx.bezierCurveTo(
+                label.w - 5,
+                0,
+                label.w,
+                label.h / 2,
+                label.w,
+                label.h / 2
+            );
+            ctx.bezierCurveTo(
+                label.w,
+                label.h / 2,
+                label.w - 5,
+                label.h,
+                curveStart,
+                label.h
+            );
+            ctx.lineTo(2, label.h);
+            ctx.bezierCurveTo(1, label.h, 0, label.h - 1, 0, label.h - 2);
+            ctx.closePath();
+            ctx.fill();
 
-        ctx.textAlign = 'right';
-        ctx.fillStyle = white;
-        ctx.fillText(formatY(triggerLevel), label.w - 18, label.h / 2 + 4);
+            ctx.lineWidth = 1;
+            ctx.strokeStyle = colors.gray50;
+            ctx.beginPath();
+            ctx.closePath();
+            ctx.stroke();
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        function drawHandleLines() {
+            ctx.lineWidth = 1;
+            ctx.strokeStyle = colors.gray50;
+            ctx.beginPath();
+            ctx.moveTo(4, 3);
+            ctx.lineTo(4, label.h - 3);
+            ctx.moveTo(8, 3);
+            ctx.lineTo(8, label.h - 3);
+            ctx.moveTo(12, 3);
+            ctx.lineTo(12, label.h - 3);
+            ctx.closePath();
+            ctx.stroke();
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        function drawText() {
+            ctx.textAlign = 'right';
+            ctx.fillStyle = white;
+            ctx.fillText(formatY(triggerLevel), label.w - 18, label.h / 2 + 4);
+        }
+
+        drawDashedLine();
+        drawHandle();
+        // drawHandleLines();
+        // drawText(ctx);
 
         ctx.restore();
     },

--- a/src/components/Chart/plugins/chart.triggerLevel.js
+++ b/src/components/Chart/plugins/chart.triggerLevel.js
@@ -183,32 +183,8 @@ const plugin = {
             ctx.stroke();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        function drawHandleLines() {
-            ctx.lineWidth = 1;
-            ctx.strokeStyle = colors.gray50;
-            ctx.beginPath();
-            ctx.moveTo(4, 3);
-            ctx.lineTo(4, label.h - 3);
-            ctx.moveTo(8, 3);
-            ctx.lineTo(8, label.h - 3);
-            ctx.moveTo(12, 3);
-            ctx.lineTo(12, label.h - 3);
-            ctx.closePath();
-            ctx.stroke();
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        function drawText() {
-            ctx.textAlign = 'right';
-            ctx.fillStyle = white;
-            ctx.fillText(formatY(triggerLevel), label.w - 18, label.h / 2 + 4);
-        }
-
         drawDashedLine();
         drawHandle();
-        // drawHandleLines();
-        // drawText(ctx);
 
         ctx.restore();
     },

--- a/src/components/__tests__/ExportDialog-test.jsx
+++ b/src/components/__tests__/ExportDialog-test.jsx
@@ -1,0 +1,75 @@
+/* Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+import { render, screen } from '../../utils/testUtils';
+import ExportDialog from '../SaveExport/ExportDialog';
+
+jest.mock('nrfconnect/core', () => {
+    return {
+        getAppDataDir: () => '',
+    };
+});
+
+const initialState = {
+    app: {
+        chart: {
+            windowBegin: 0,
+            windowEnd: 999999,
+            cursorBegin: null,
+            hasDigitalChannels: true,
+        },
+        app: {
+            isExportDialogVisible: true,
+        },
+    },
+};
+
+describe('ExportDialog', () => {
+    render(<ExportDialog />, { initialState });
+    const numberOfRecordsText = '100000 records';
+    const totalSizeLargerThanZeroPattern = /[1-9][0-9]*\sMB/;
+    const durationLargerThanZeroPattern = /[1-9][0-9]*\ss/;
+
+    it('should show the number of records', () => {
+        const numberOfRecords = screen.getByText(numberOfRecordsText);
+        expect(numberOfRecords).not.toBe(undefined);
+        const totalSize = screen.getByText(totalSizeLargerThanZeroPattern);
+        expect(totalSize).not.toBe(undefined);
+        const duration = screen.getByText(durationLargerThanZeroPattern);
+        expect(duration).not.toBe(undefined);
+    });
+});

--- a/src/components/__tests__/TimeSpan-test.jsx
+++ b/src/components/__tests__/TimeSpan-test.jsx
@@ -35,41 +35,53 @@
  */
 
 import React from 'react';
-import { render, screen } from '../../../utils/testUtils';
-import ExportDialog from '../ExportDialog';
-
-jest.mock('nrfconnect/core', () => {
-    return {
-        getAppDataDir: () => '',
-    };
-});
+import { render, screen } from '../../utils/testUtils';
+import TimeSpanTop from '../Chart/TimeSpan/TimeSpanTop';
 
 const initialState = {
     app: {
         chart: {
-            windowBegin: 0,
-            windowEnd: 999999,
-            cursorBegin: null,
-            hasDigitalChannels: true,
+            windowDuration: 1000,
+        },
+        trigger: {
+            triggerRunning: false,
+            triggerWindowOffset: 0,
         },
         app: {
-            isExportDialogVisible: true,
+            capabilities: {
+                prePostTriggering: false,
+            },
         },
     },
 };
 
-describe('ExportDialog', () => {
-    render(<ExportDialog />, { initialState });
-    const numberOfRecordsText = '100000 records';
-    const totalSizeLargerThanZeroPattern = /[1-9][0-9]*\sMB/;
-    const durationLargerThanZeroPattern = /[1-9][0-9]*\ss/;
+test('should hide offset handler if device does not support it', () => {
+    render(<TimeSpanTop />, { initialState });
 
-    it('should show the number of records', () => {
-        const numberOfRecords = screen.getByText(numberOfRecordsText);
-        expect(numberOfRecords).not.toBe(undefined);
-        const totalSize = screen.getByText(totalSizeLargerThanZeroPattern);
-        expect(totalSize).not.toBe(undefined);
-        const duration = screen.getByText(durationLargerThanZeroPattern);
-        expect(duration).not.toBe(undefined);
+    const handler = screen.queryByTestId('offsetHandler');
+    expect(handler).toBeNull();
+});
+
+test('should show offset handler if trigger running and device has capabilities', () => {
+    const triggerRunningWithCapabilitiesState = {
+        app: {
+            ...initialState.app,
+            trigger: {
+                ...initialState.app.trigger,
+                triggerRunning: true,
+            },
+            app: {
+                capabilities: {
+                    prePostTriggering: true,
+                },
+            },
+        },
+    };
+
+    render(<TimeSpanTop />, {
+        initialState: triggerRunningWithCapabilitiesState,
     });
+
+    const handler = screen.queryByTestId('offsetHandler');
+    expect(handler).not.toBeNull();
 });

--- a/src/reducers/chartReducer.js
+++ b/src/reducers/chartReducer.js
@@ -74,7 +74,6 @@ const TOGGLE_TIMESTAMPS = 'TOGGLE_TIMESTAMPS';
 const UPDATE_HAS_DIGITAL_CHANNELS = 'UPDATE_HAS_DIGITAL_CHANNELS';
 const TOGGLE_Y_AXIS_LOCK = 'TOGGLE_Y_AXIS_LOCK';
 const TOGGLE_GRID_LINES = 'TOGGLE_GRID_LINES';
-const SET_WINDOW_OFFSET = 'SET_WINDOW_OFFSET';
 
 const MIN_WINDOW_DURATION = 500;
 const MAX_WINDOW_DURATION = 120000000;
@@ -267,11 +266,6 @@ export default (state = initialState, { type, ...action }) => {
             return {
                 ...state,
                 showGridLines: !state.showGridLines,
-            };
-        case SET_WINDOW_OFFSET:
-            return {
-                ...state,
-                triggerWindowOffset: action.offset,
             };
         case UPDATE_HAS_DIGITAL_CHANNELS:
             return { ...state, ...action };

--- a/src/reducers/chartReducer.js
+++ b/src/reducers/chartReducer.js
@@ -61,7 +61,7 @@ const initialState = {
     digitalChannelsVisible: persistentStore.get('digitalChannelsVisible', true),
     timestampsVisible: persistentStore.get('timestampsVisible', false),
     yAxisLock: false,
-    showGridLines: true,
+    showGridLines: persistentStore.get('gridlinesVisible', true),
 };
 
 const ANIMATION = 'ANIMATION';
@@ -263,6 +263,7 @@ export default (state = initialState, { type, ...action }) => {
             return { ...s, ...action, yAxisLock: !state.yAxisLock };
         }
         case TOGGLE_GRID_LINES:
+            persistentStore.set('gridlinesVisible', !state.showGridLines);
             return {
                 ...state,
                 showGridLines: !state.showGridLines,

--- a/src/reducers/chartReducer.js
+++ b/src/reducers/chartReducer.js
@@ -61,8 +61,7 @@ const initialState = {
     digitalChannelsVisible: persistentStore.get('digitalChannelsVisible', true),
     timestampsVisible: persistentStore.get('timestampsVisible', false),
     yAxisLock: false,
-    preSamplingOn: false,
-    postSamplingOn: false,
+    showGridLines: true,
 };
 
 const ANIMATION = 'ANIMATION';
@@ -74,8 +73,8 @@ const TOGGLE_DIGITAL_CHANNELS = 'TOGGLE_DIGITAL_CHANNELS';
 const TOGGLE_TIMESTAMPS = 'TOGGLE_TIMESTAMPS';
 const UPDATE_HAS_DIGITAL_CHANNELS = 'UPDATE_HAS_DIGITAL_CHANNELS';
 const TOGGLE_Y_AXIS_LOCK = 'TOGGLE_Y_AXIS_LOCK';
-const TOGGLE_PRE_SAMPLING = 'TOGGLE_PRE_SAMPLING';
-const TOGGLE_POST_SAMPLING = 'TOGGLE_POST_SAMPLING';
+const TOGGLE_GRID_LINES = 'TOGGLE_GRID_LINES';
+const SET_WINDOW_OFFSET = 'SET_WINDOW_OFFSET';
 
 const MIN_WINDOW_DURATION = 500;
 const MAX_WINDOW_DURATION = 120000000;
@@ -176,11 +175,8 @@ export const toggleYAxisLock = (yMin, yMax) => ({
     yMin,
     yMax,
 });
-export const togglePreSampling = () => ({
-    type: TOGGLE_PRE_SAMPLING,
-});
-export const togglePostSampling = () => ({
-    type: TOGGLE_POST_SAMPLING,
+export const toggleGridLines = () => ({
+    type: TOGGLE_GRID_LINES,
 });
 
 function calcBuffer(windowDuration, windowEnd) {
@@ -267,15 +263,15 @@ export default (state = initialState, { type, ...action }) => {
             const { yMin, yMax, ...s } = state;
             return { ...s, ...action, yAxisLock: !state.yAxisLock };
         }
-        case TOGGLE_PRE_SAMPLING:
+        case TOGGLE_GRID_LINES:
             return {
                 ...state,
-                preSamplingOn: !state.preSamplingOn,
+                showGridLines: !state.showGridLines,
             };
-        case TOGGLE_POST_SAMPLING:
+        case SET_WINDOW_OFFSET:
             return {
                 ...state,
-                postSamplingOn: !state.postSamplingOn,
+                triggerWindowOffset: action.offset,
             };
         case UPDATE_HAS_DIGITAL_CHANNELS:
             return { ...state, ...action };

--- a/src/reducers/triggerReducer.js
+++ b/src/reducers/triggerReducer.js
@@ -45,6 +45,7 @@ const initialState = {
         max: (4000 * 13) / 1e3,
     },
     triggerStartIndex: null,
+    triggerWindowOffset: 0,
 };
 
 export const EXTERNAL_TRIGGER_TOGGLE = 'EXTERNAL_TRIGGER_TOGGLE';
@@ -55,6 +56,7 @@ export const TRIGGER_LEVEL_SET = 'TRIGGER_LEVEL_SET';
 export const TRIGGER_LENGTH_SET = 'TRIGGER_LENGTH_SET';
 export const TRIGGER_WINDOW_RANGE = 'TRIGGER_WINDOW_RANGE';
 export const SET_TRIGGER_START = 'SET_TRIGGER_START';
+export const SET_WINDOW_OFFSET = 'SET_WINDOW_OFFSET';
 
 export const triggerLevelSetAction = triggerLevel => ({
     type: TRIGGER_LEVEL_SET,
@@ -87,6 +89,11 @@ export const externalTriggerToggledAction = () => ({
 export const triggerWindowRangeAction = ({ min, max }) => ({
     type: TRIGGER_WINDOW_RANGE,
     triggerWindowRange: { min, max },
+});
+
+export const setWindowOffsetAction = offset => ({
+    type: SET_WINDOW_OFFSET,
+    offset,
 });
 
 export default (state = initialState, { type, ...action }) => {
@@ -135,6 +142,11 @@ export default (state = initialState, { type, ...action }) => {
             return {
                 ...state,
                 triggerStartIndex: action.triggerStartIndex,
+            };
+        case SET_WINDOW_OFFSET:
+            return {
+                ...state,
+                triggerWindowOffset: action.offset,
             };
         case TRIGGER_LEVEL_SET:
         case TRIGGER_LENGTH_SET:

--- a/src/utils/panes.js
+++ b/src/utils/panes.js
@@ -34,6 +34,15 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// This utility cannot be used within other hooks (e.g. useEffect and useCallback). If you want to check
+// the current pane inside useEffect you should create a variable first and
+// check that, e.g.
+//
+// const isScope = getScopePane();
+// useEffect(() => {
+//   if (isScope) ...
+// }, [isScope])
+
 import { useSelector } from 'react-redux';
 import { currentPane as currentPaneSelector } from '../reducers/appReducer';
 
@@ -54,8 +63,7 @@ const getCurrentPane = (pane, currentPane = null) => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         return useSelector(currentPaneSelector) === pane;
     } catch (err) {
-        const errorMessage =
-            'The current pane (number) should be passed in as argument when used outside a React component';
+        const errorMessage = `The current pane (number) should be passed in as argument when used outside a React component.\n${err}`;
         console.error(errorMessage);
         throw new Error(errorMessage);
     }


### PR DESCRIPTION
## Add window shift functionality for supported devices.

This pull requests will add functionality that grants the user more control over what they want to see when doing triggering. They can now slide the window back and forth to highlight precisely the portion of the signal signature that is most interesting.

![image](https://user-images.githubusercontent.com/72191781/102220388-06f1b680-3ee1-11eb-9f3d-74022e446ff1.png)

This new handle will only be visible for supported hardware (only PPK2 as of now) and only while triggering.

# Toggle grid

We also add a switch to toggle the grid in the chart.

![image](https://user-images.githubusercontent.com/72191781/102220545-43bdad80-3ee1-11eb-8abb-2095b4282e38.png)

# Misc

- The design of trigger-level handle was modified according to the sketches and the trigger level value is no longer shown inside the handle. Therefore we now update the triggerlevel input field in the Sidepanel continuously while the handle is moved to provide visual feedback to the user.

![image](https://user-images.githubusercontent.com/72191781/102220752-87b0b280-3ee1-11eb-8ff7-507c2c100746.png)
- Remove old pre/post-sampling functionality