### PR TITLE
Fix/load save sidepanel

### DIFF
--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -49,6 +49,7 @@ import {
     setPowerModeAction,
     samplingStartAction,
     samplingStoppedAction,
+    setFileLoadedAction,
 } from '../reducers/appReducer';
 import {
     switchingPointsResetAction,
@@ -320,6 +321,7 @@ export function open(deviceInfo) {
             }
 
             dispatch(rttStartAction());
+            dispatch(setFileLoadedAction(false));
 
             if (isRealTimePane(currentPane)) {
                 initializeChartForRealTime();

--- a/src/actions/fileActions.js
+++ b/src/actions/fileActions.js
@@ -43,6 +43,7 @@ import { join, dirname } from 'path';
 import { logger } from 'nrfconnect/core';
 import { options, updateTitle } from '../globals';
 import { setChartState } from '../reducers/chartReducer';
+import { setFileLoadedAction } from '../reducers/appReducer';
 
 import { lastSaveDir, setLastSaveDir } from '../utils/persistentStore';
 
@@ -150,6 +151,7 @@ export const load = () => async dispatch => {
     }
 
     dispatch(setChartState(chartState));
+    dispatch(setFileLoadedAction(true));
     logger.info(`State restored from: ${filename}`);
 };
 

--- a/src/components/SidePanel/Instructions.jsx
+++ b/src/components/SidePanel/Instructions.jsx
@@ -79,7 +79,7 @@ export default () => (
         </Button>
         <Button
             variant="set"
-            className="mt-3"
+            className="mt-3 w-100"
             onClick={() => openUrl(urls.purchase)}
         >
             Get PPK2 device

--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -52,6 +52,7 @@ import {
     toggleAdvancedModeAction,
     advancedMode as advancedModeSelector,
     deviceOpen as deviceOpenSelector,
+    appState,
 } from '../../reducers/appReducer';
 
 import { options } from '../../globals';
@@ -67,9 +68,20 @@ export default () => {
 
     const advancedMode = useSelector(advancedModeSelector);
     const deviceOpen = useSelector(deviceOpenSelector);
+    const { fileLoaded } = useSelector(appState);
 
     const realTimePane = isRealTimePane();
     const dataLoggerPane = isDataLoggerPane();
+
+    if (fileLoaded) {
+        return (
+            <SidePanel className="side-panel">
+                <Load />
+                <DisplayOptions />
+                <Save />
+            </SidePanel>
+        );
+    }
 
     if (!deviceOpen) {
         return (

--- a/src/reducers/appReducer.js
+++ b/src/reducers/appReducer.js
@@ -45,6 +45,7 @@ const initialState = {
     samplingRunning: false,
     isSaveChoiceDialogVisible: false,
     isExportDialogVisible: false,
+    fileLoaded: false,
 };
 
 const DEVICE_CLOSED = 'DEVICE_CLOSED';
@@ -58,6 +59,7 @@ const TOGGLE_ADVANCED_MODE = 'TOGGLE_ADVANCED_MODE';
 const TOGGLE_SAVE_CHOICE_DIALOG = 'TOGGLE_SAVE_CHOICE_DIALOG';
 const SHOW_EXPORT_DIALOG = 'SHOW_EXPORT_DIALOG';
 const HIDE_EXPORT_DIALOG = 'HIDE_EXPORT_DIALOG';
+const SET_FILE_LOADED = 'SET_FILE_LOADED';
 
 export const toggleAdvancedModeAction = () => ({ type: TOGGLE_ADVANCED_MODE });
 export const samplingStartAction = () => ({ type: SAMPLING_STARTED });
@@ -87,6 +89,11 @@ export const toggleSaveChoiceDialog = () => ({
 export const showExportDialog = () => ({ type: SHOW_EXPORT_DIALOG });
 export const hideExportDialog = () => ({ type: HIDE_EXPORT_DIALOG });
 
+export const setFileLoadedAction = loaded => ({
+    type: SET_FILE_LOADED,
+    loaded,
+});
+
 export default (state = initialState, { type, ...action }) => {
     switch (type) {
         case DEVICE_OPENED: {
@@ -111,6 +118,11 @@ export default (state = initialState, { type, ...action }) => {
             return {
                 ...state,
                 isSaveChoiceDialogVisible: !state.isSaveChoiceDialogVisible,
+            };
+        case SET_FILE_LOADED:
+            return {
+                ...state,
+                fileLoaded: action.loaded,
             };
         case SHOW_EXPORT_DIALOG:
             return { ...state, isExportDialogVisible: true };


### PR DESCRIPTION
## Updates to saving/loading files

### Update sidepanel content
We change the content of the sidepanel when a ppk file is loaded to show display options, save/export and screenshot.
![image](https://user-images.githubusercontent.com/72191781/102624422-4a982a80-4144-11eb-9601-c8c667e8ecf9.png)

### Save current pane
We now add the current pane information to the save-file, such that the user is directed to the correct pane when loading a file.
