### PR TITLE
Reset trigger window offset slider to initial position when trigger length is changed

### DIFF
--- a/src/reducers/triggerReducer.js
+++ b/src/reducers/triggerReducer.js
@@ -148,8 +148,10 @@ export default (state = initialState, { type, ...action }) => {
                 ...state,
                 triggerWindowOffset: action.offset,
             };
+        case TRIGGER_LENGTH_SET: {
+            return { ...state, ...action, triggerWindowOffset: 0 };
+        }
         case TRIGGER_LEVEL_SET:
-        case TRIGGER_LENGTH_SET:
         case TRIGGER_WINDOW_RANGE: {
             return { ...state, ...action };
         }


### PR DESCRIPTION
Currently the window offset slider handle disappears if the trigger length is reduced while the handle is not in its initial position. To remedy this we reset the handle to its initial position whenever the trigger length is modified.

![handle_disappears](https://user-images.githubusercontent.com/72191781/103465893-1aee4280-4d40-11eb-8a2c-4a5bd5a6e19d.gif)
