### PR TITLE
Enhance performance by throttling critical events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 ### Updates
 - Add screenshot functionality
 - Split real-time and data logger views
+- Enhanced performance to make the UI more responsive
 
 ## Version 3.0.2
 ## Fixed


### PR DESCRIPTION
There can be an overwhelming amount of mouse move or wheel events which hurts the performance. This PR enhances that situation by utilising `requestAnimationFrame`.

If multiple events occurred before the next animation frame is drawn, the computations is only done once, thus the system is not overwhelmed so easily by the events.

And the computations are done for the last event, not for older ones, which should also make the system appear more responsive.