### PR TITLE
Fix burst of data after sampling is stopped

### DIFF
--- a/src/actions/__tests__/triggerActions-test.js
+++ b/src/actions/__tests__/triggerActions-test.js
@@ -120,6 +120,7 @@ describe('Handle trigger', () => {
             processTriggerSample(5, mockDevice, {
                 ...samplingData,
                 dataIndex: newIndex,
+                endOfTrigger: true,
             })
         );
         expect(store.getActions()).toEqual(
@@ -149,6 +150,7 @@ describe('Handle trigger', () => {
                 processTriggerSample(5, mockDevice, {
                     ...samplingData,
                     dataIndex: newIndex,
+                    endOfTrigger: true,
                 })
             );
             expect(store.getActions()).toEqual([
@@ -182,6 +184,7 @@ describe('Handle trigger', () => {
                 processTriggerSample(5, mockDevice, {
                     ...samplingData,
                     dataIndex: 499,
+                    endOfTrigger: false,
                 })
             );
             expect(store.getActions().length).toBe(0);
@@ -189,6 +192,7 @@ describe('Handle trigger', () => {
                 processTriggerSample(5, mockDevice, {
                     ...samplingData,
                     dataIndex: 500,
+                    endOfTrigger: true,
                 })
             );
             expect(store.getActions().length).toBe(2);

--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -237,8 +237,7 @@ export function open(deviceInfo) {
             dispatch(chartWindowAction(0, end, end));
         };
 
-        const onSample = ({ value, bits }) => {
-            // PPK1 always sets timestamp, while PPK2 never does
+        const onSample = ({ value, bits, endOfTrigger }) => {
             if (options.timestamp === undefined) {
                 options.timestamp = 0;
             }
@@ -246,7 +245,20 @@ export function open(deviceInfo) {
             const {
                 app: { samplingRunning },
                 dataLogger: { maxSampleFreq, sampleFreq },
+                trigger: {
+                    triggerRunning,
+                    triggerStartIndex,
+                    triggerSingleWaiting,
+                },
             } = getState().app;
+            if (
+                !triggerRunning &&
+                !samplingRunning &&
+                !triggerStartIndex &&
+                !triggerSingleWaiting
+            ) {
+                return;
+            }
             const { currentPane } = getState().appLayout;
 
             let zeroCappedValue = zeroCap(value);
@@ -285,6 +297,7 @@ export function open(deviceInfo) {
                         samplingTime: options.samplingTime,
                         dataIndex: options.index,
                         dataBuffer: options.data,
+                        endOfTrigger,
                     })
                 );
             }


### PR DESCRIPTION
This PR fixes the incoming data burst after sampling is stopped. Also, there was a bug in the condition to handle end-of-trigger, due to the differences of the software trigger implementation for PPK2 and the way how the hardware trigger works with PPK1.