### PR TITLE
Stop sampling when buffer is full

### DIFF
--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -295,6 +295,9 @@ export function open(deviceInfo) {
             options.timestamp += options.samplingTime;
 
             if (options.index === options.data.length) {
+                if (samplingRunning) {
+                    dispatch(samplingStop());
+                }
                 options.index = 0;
             }
             if (triggerRunning || triggerSingleWaiting) {


### PR DESCRIPTION
This PR disables the buffer rollover functionality for the data logger.