### PR TITLE
Fix/time delta window selection

### DIFF
--- a/src/components/Chart/TimeSpan/TimeSpanBottom.jsx
+++ b/src/components/Chart/TimeSpan/TimeSpanBottom.jsx
@@ -76,6 +76,10 @@ const TimeSpanBottom = ({ cursorBegin = null, cursorEnd = null, width }) => {
         target.releasePointerCapture(pointerId);
         setDrag(null);
     };
+    const timeDelta =
+        cursorBegin && cursorEnd
+            ? Math.abs(cursorEnd - cursorBegin)
+            : windowDuration;
     return (
         <div className="timespan selection" style={{ width }}>
             {showHandles && (
@@ -103,7 +107,12 @@ const TimeSpanBottom = ({ cursorBegin = null, cursorEnd = null, width }) => {
                     </svg>
                 </div>
             )}
-            <TimeSpanLabel duration={windowDuration} />
+            <TimeSpanLabel
+                duration={timeDelta}
+                begin={cursorBegin ? cursorBegin - w0 : null}
+                end={cursorEnd ? cursorEnd - w0 : null}
+                totalDuration={windowDuration}
+            />
             {showHandles && (
                 <div
                     className="cursor end"

--- a/src/components/Chart/TimeSpan/TimeSpanLabel.jsx
+++ b/src/components/Chart/TimeSpan/TimeSpanLabel.jsx
@@ -48,10 +48,11 @@ const formatTime = duration => {
 };
 
 const TimeSpanLabel = ({ begin, end, duration, totalDuration = duration }) => {
-    const start = begin !== undefined ? (100 * begin) / totalDuration : 0;
+    const [nBegin, nEnd] = begin > end ? [end, begin] : [begin, end];
+    const start = nBegin != null ? (100 * nBegin) / totalDuration : 0;
     const width =
-        begin !== undefined && end !== undefined
-            ? (100 * (end - begin)) / totalDuration
+        nBegin != null && nEnd !== null
+            ? (100 * (nEnd - nBegin)) / totalDuration
             : 100;
 
     const [valStr, unitStr] = formatTime(duration);

--- a/src/device/serialDevice.js
+++ b/src/device/serialDevice.js
@@ -77,8 +77,6 @@ class SerialDevice extends Device {
 
     isRunningInitially = false;
 
-    numberOfSamplesIn5Ms = 500;
-
     constructor(deviceInfo) {
         super();
 


### PR DESCRIPTION
If there is a selection in the chart we want the time delta label to show the distance between the two cursors defining the size of the selection. In previous versions (3.0) there was a bug where pulling the left cursor past the right one would break the label. This is also fixed in this PR.

![image](https://user-images.githubusercontent.com/72191781/105157434-40839600-5b0d-11eb-9836-e809ed465441.png)
