### PR TITLE
Fix/blinking nan

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -179,6 +179,7 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
             ? digitalChannelsToDisplay
             : [];
 
+    if (options.timestamp === undefined) options.timestamp = 0;
     const end = windowEnd || options.timestamp - options.samplingTime;
     const begin = windowBegin || end - windowDuration;
 

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -179,8 +179,10 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
             ? digitalChannelsToDisplay
             : [];
 
-    if (options.timestamp === undefined) options.timestamp = 0;
-    const end = windowEnd || options.timestamp - options.samplingTime;
+    const end =
+        windowEnd || options.timestamp
+            ? options.timestamp - options.samplingTime
+            : 0;
     const begin = windowBegin || end - windowDuration;
 
     const cursorData = {
@@ -268,8 +270,7 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
 
     const originalIndexBegin = timestampToIndex(begin, index);
     const originalIndexEnd = timestampToIndex(end, index);
-    const step = (originalIndexEnd - originalIndexBegin) / len;
-
+    const step = len === 0 ? 2 : (originalIndexEnd - originalIndexBegin) / len;
     const { ampereLineData, bitsLineData } = useMemo(() => {
         const dataProcessor = step > 1 ? dataAccumulator : dataSelector;
 

--- a/src/components/Chart/data/dataAccumulator.js
+++ b/src/components/Chart/data/dataAccumulator.js
@@ -58,7 +58,8 @@ export default () => ({
 
         const originalIndexBegin = timestampToIndex(begin, index);
         const originalIndexEnd = timestampToIndex(end, index);
-        const step = (originalIndexEnd - originalIndexBegin) / len;
+        const step =
+            len === 0 ? 0 : (originalIndexEnd - originalIndexBegin) / len;
 
         let mappedIndex = 0;
 


### PR DESCRIPTION
This PR fixes an issue with blinking labels when we start sampling.

![nan-y-axis](https://user-images.githubusercontent.com/72191781/105326643-40979a80-5bce-11eb-8687-2558c5b6fb3d.gif)

For a brief moment, the timestamp will be undefined, which gives NaN when we attempt to subtract a number. To prevent this from happening we provide the timestamp with a default value of 0. I don't know yet if this has unintended consequences, but I haven't seen any yet.

In addition we prevent a division by 0 that currently happens but I cannot see that it has any consequences currently, so we just avoid it to be safe.
