### PR TITLE
Move voltage regulator component according to mockups

### DIFF
--- a/src/components/SidePanel/PowerMode.jsx
+++ b/src/components/SidePanel/PowerMode.jsx
@@ -40,6 +40,7 @@ import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import { Group } from 'pc-nrfconnect-shared';
 import { Toggle } from '../../from_pc-nrfconnect-shared';
+import VoltageRegulator from './VoltageRegulator';
 
 import { setPowerMode, setDeviceRunning } from '../../actions/deviceActions';
 import { appState } from '../../reducers/appReducer';
@@ -73,6 +74,7 @@ export default () => {
                     </Button>
                 </ButtonGroup>
             )}
+            <VoltageRegulator />
             {capabilities.ppkDeviceRunning && (
                 <Toggle
                     title="Turn power on/off for device under test"

--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -42,7 +42,6 @@ import PowerMode from './PowerMode';
 import DisplayOptions from './DisplayOptions';
 import StartStop from './StartStop';
 import Trigger from './Trigger/Trigger';
-import VoltageRegulator from './VoltageRegulator';
 import SwitchPoints from './SwitchPoints';
 import ResistorCalibration from './ResistorCalibration';
 import Gains from './Gains';
@@ -112,7 +111,6 @@ export default () => {
             <PowerMode />
             {realTimePane && <Trigger />}
             {dataLoggerPane && <StartStop />}
-            <VoltageRegulator />
             {options.timestamp === null || (
                 <>
                     <DisplayOptions />

--- a/src/components/SidePanel/VoltageRegulator.jsx
+++ b/src/components/SidePanel/VoltageRegulator.jsx
@@ -37,9 +37,8 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import Form from 'react-bootstrap/Form';
 import BootstrapCollapse from 'react-bootstrap/Collapse';
-import { CollapsibleGroup } from 'pc-nrfconnect-shared';
+import Form from 'react-bootstrap/Form';
 import { NumberInlineInput, Slider } from '../../from_pc-nrfconnect-shared';
 
 import { updateRegulator } from '../../actions/deviceActions';
@@ -62,33 +61,28 @@ const VoltageRegulator = () => {
 
     return (
         <BootstrapCollapse in={isVoltageSettable}>
-            <div>
-                <CollapsibleGroup heading="Voltage adjustment">
-                    <Form.Label htmlFor="slider-vdd">
-                        <span className="flex-fill">Supply</span>
-                        <NumberInlineInput
-                            value={vdd}
-                            range={{ min, max }}
-                            onChange={value =>
-                                dispatch(moveVoltageRegulatorVddAction(value))
-                            }
-                            onChangeComplete={() =>
-                                dispatch(updateRegulator(vdd))
-                            }
-                        />{' '}
-                        mV
-                    </Form.Label>
-                    <Slider
-                        id="slider-vdd"
-                        values={[vdd]}
+            <div className="voltage-regulator">
+                <Form.Label htmlFor="slider-vdd">
+                    <span className="flex-fill">Set supply voltage to</span>
+                    <NumberInlineInput
+                        value={vdd}
                         range={{ min, max }}
-                        onChange={[
-                            value =>
-                                dispatch(moveVoltageRegulatorVddAction(value)),
-                        ]}
+                        onChange={value =>
+                            dispatch(moveVoltageRegulatorVddAction(value))
+                        }
                         onChangeComplete={() => dispatch(updateRegulator(vdd))}
-                    />
-                </CollapsibleGroup>
+                    />{' '}
+                    mV
+                </Form.Label>
+                <Slider
+                    id="slider-vdd"
+                    values={[vdd]}
+                    range={{ min, max }}
+                    onChange={[
+                        value => dispatch(moveVoltageRegulatorVddAction(value)),
+                    ]}
+                    onChangeComplete={() => dispatch(updateRegulator(vdd))}
+                />
             </div>
         </BootstrapCollapse>
     );

--- a/src/components/SidePanel/sidepanel.scss
+++ b/src/components/SidePanel/sidepanel.scss
@@ -91,4 +91,9 @@
     .start-btn {
         margin-top: 24px;
     }
+
+    .voltage-regulator {
+        margin-top: 8px;
+        margin-bottom: 16px;
+    }
 }


### PR DESCRIPTION
This PR implements [NCP-3532](https://projecttools.nordicsemi.no/jira/browse/NCP-3532). Basically we just move the voltage regulator to a more logical grouping and remove the header.