### PR TITLE
Replace enable power output toggle in Ampere mode

### DIFF
--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -348,9 +348,11 @@ export function open(deviceInfo) {
                 dispatch(updateSpikeFilter());
             }
             if (device.capabilities.ppkSetPowerMode) {
+                const isSmuMode = metadata.mode === 2;
                 // 1 = Ampere
                 // 2 = SMU
-                dispatch(setPowerModeAction(metadata.mode === 2));
+                dispatch(setPowerModeAction(isSmuMode));
+                if (!isSmuMode) dispatch(setDeviceRunning(true));
             }
 
             dispatch(rttStartAction());

--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -475,6 +475,7 @@ export function setPowerMode(isSmuMode) {
         await device.ppkSetPowerMode(isSmuMode ? 2 : 1);
         logger.info(`Mode: ${isSmuMode ? 'Source meter' : 'Ampere meter'}`);
         dispatch(setPowerModeAction(isSmuMode));
+        if (!isSmuMode) dispatch(setDeviceRunning(true));
     };
 }
 

--- a/src/components/SidePanel/PowerMode.jsx
+++ b/src/components/SidePanel/PowerMode.jsx
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
@@ -49,6 +49,15 @@ export default () => {
     const dispatch = useDispatch();
     const { capabilities, isSmuMode, deviceRunning } = useSelector(appState);
     const togglePowerMode = () => dispatch(setPowerMode(!isSmuMode));
+
+    useEffect(() => {
+        const shouldBePoweredOn = !isSmuMode && !deviceRunning;
+        if (shouldBePoweredOn) {
+            setTimeout(() => {
+                dispatch(setDeviceRunning(true));
+            }, 10);
+        }
+    }, [isSmuMode, deviceRunning, dispatch]);
 
     return (
         <Group heading="Mode">
@@ -75,7 +84,7 @@ export default () => {
                 </ButtonGroup>
             )}
             <VoltageRegulator />
-            {capabilities.ppkDeviceRunning && (
+            {capabilities.ppkDeviceRunning && isSmuMode && (
                 <Toggle
                     title="Turn power on/off for device under test"
                     onToggle={() => dispatch(setDeviceRunning(!deviceRunning))}
@@ -83,6 +92,15 @@ export default () => {
                     label="Enable power output"
                     variant="secondary"
                 />
+            )}
+            {capabilities.ppkDeviceRunning && !isSmuMode && (
+                <Button
+                    variant="set"
+                    className="w-100 power-cycle-btn"
+                    onClick={() => dispatch(setDeviceRunning(false))}
+                >
+                    Power cycle DUT
+                </Button>
             )}
         </Group>
     );

--- a/src/components/SidePanel/PowerMode.jsx
+++ b/src/components/SidePanel/PowerMode.jsx
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
@@ -48,16 +48,19 @@ import { appState } from '../../reducers/appReducer';
 export default () => {
     const dispatch = useDispatch();
     const { capabilities, isSmuMode, deviceRunning } = useSelector(appState);
-    const togglePowerMode = () => dispatch(setPowerMode(!isSmuMode));
 
-    useEffect(() => {
-        const shouldBePoweredOn = !isSmuMode && !deviceRunning;
-        if (shouldBePoweredOn) {
-            setTimeout(() => {
-                dispatch(setDeviceRunning(true));
-            }, 10);
-        }
-    }, [isSmuMode, deviceRunning, dispatch]);
+    const togglePowerMode = () => {
+        const toggledSmuMode = !isSmuMode;
+        dispatch(setPowerMode(toggledSmuMode));
+        if (!toggledSmuMode) dispatch(setDeviceRunning(true));
+    };
+
+    const powerCycle = () => {
+        dispatch(setDeviceRunning(false));
+        setTimeout(() => {
+            dispatch(setDeviceRunning(true));
+        }, 20);
+    };
 
     return (
         <Group heading="Mode">
@@ -97,7 +100,7 @@ export default () => {
                 <Button
                     variant="set"
                     className="w-100 power-cycle-btn"
-                    onClick={() => dispatch(setDeviceRunning(false))}
+                    onClick={powerCycle}
                 >
                     Power cycle DUT
                 </Button>

--- a/src/components/SidePanel/PowerMode.jsx
+++ b/src/components/SidePanel/PowerMode.jsx
@@ -49,11 +49,7 @@ export default () => {
     const dispatch = useDispatch();
     const { capabilities, isSmuMode, deviceRunning } = useSelector(appState);
 
-    const togglePowerMode = () => {
-        const toggledSmuMode = !isSmuMode;
-        dispatch(setPowerMode(toggledSmuMode));
-        if (!toggledSmuMode) dispatch(setDeviceRunning(true));
-    };
+    const togglePowerMode = () => dispatch(setPowerMode(!isSmuMode));
 
     const powerCycle = () => {
         dispatch(setDeviceRunning(false));

--- a/src/components/SidePanel/sidepanel.scss
+++ b/src/components/SidePanel/sidepanel.scss
@@ -96,4 +96,13 @@
         margin-top: 8px;
         margin-bottom: 16px;
     }
+
+    .power-cycle-btn {
+        height: 28px;
+        font-size: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+    }
 }


### PR DESCRIPTION
Instead we add a power cycle button which cycles the power of the DUT. Additionaly we change the behavior so that the default power state of the DUT in Ampere mode is ON.

I added a 10ms delay before powering on the DUT after it has been power off. Not sure if that is necessary, or we do require a delay, if it is enough. Someone with an actual amp mode setup will have to verify this.