### PR TITLE
Add filters to screenshot save dialog

### DIFF
--- a/src/actions/fileActions.js
+++ b/src/actions/fileActions.js
@@ -135,8 +135,14 @@ export const screenshot = () => async () => {
     });
 
     const timestamp = getTimestamp();
+    const filters = [
+        { name: 'PNG', extensions: ['png'] },
+        { name: 'All Files', extensions: ['*'] },
+    ];
+
     const { filePath: filename } = await dialog.showSaveDialog({
         defaultPath: join(lastSaveDir(), `ppk-${timestamp}.png`),
+        filters,
     });
     if (!filename) {
         return;


### PR DESCRIPTION
If we don't have filters for save dialog we risk that the file is not properly stored as a png. This happened to me after I changed the default name.