### PR TITLE
Revert changes made in 3abe186bb52298219cc287af5e2e98dc83412856

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -179,10 +179,7 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
             ? digitalChannelsToDisplay
             : [];
 
-    const end =
-        windowEnd || options.timestamp
-            ? options.timestamp - options.samplingTime
-            : 0;
+    const end = windowEnd || options.timestamp - options.samplingTime;
     const begin = windowBegin || end - windowDuration;
 
     const cursorData = {


### PR DESCRIPTION
I don't know why chart started misbehaving because of these changes, but it does so we should revert them until we have a proper fix.