### PR TITLE
Add formatting durations in different time scales

### DIFF
--- a/src/components/Chart/StatBox.jsx
+++ b/src/components/Chart/StatBox.jsx
@@ -37,6 +37,7 @@
 import React from 'react';
 import { string, instanceOf, number, node } from 'prop-types';
 import { unit, Unit } from 'mathjs';
+import { formatDurationHTML } from '../../utils/duration';
 
 import './statbox.scss';
 
@@ -64,14 +65,6 @@ Value.propTypes = {
     u: instanceOf(Unit).isRequired,
 };
 
-const time = delta => {
-    let ret = unit(delta, 'us');
-    if (delta > 60 * 1e6) {
-        ret = ret.to('min');
-    }
-    return ret;
-};
-
 const StatBox = ({
     average = null,
     max = null,
@@ -94,7 +87,9 @@ const StatBox = ({
                 <>
                     <Value label="average" u={unit(average, 'uA')} />
                     <Value label="max" u={unit(max || 0, 'uA')} />
-                    <Value label="time" u={time(delta)} />
+                    <div className="value-box">
+                        {formatDurationHTML(delta)}time
+                    </div>
                     <Value
                         label="charge"
                         u={unit(average * ((delta || 1) / 1e6), 'uC')}

--- a/src/components/Chart/TimeSpan/TimeSpanLabel.jsx
+++ b/src/components/Chart/TimeSpan/TimeSpanLabel.jsx
@@ -35,17 +35,8 @@
  */
 
 import React from 'react';
-import { unit } from 'mathjs';
 import { number } from 'prop-types';
-
-const formatTime = duration => {
-    let time = unit(duration, 'us');
-    if (duration > 60 * 1e6) {
-        time = time.to('min');
-    }
-    const v = time.format({ notation: 'fixed', precision: 2 });
-    return v.split(' ');
-};
+import { formatDuration } from '../../../utils/duration';
 
 const TimeSpanLabel = ({ begin, end, duration, totalDuration = duration }) => {
     const [nBegin, nEnd] = begin > end ? [end, begin] : [begin, end];
@@ -55,8 +46,7 @@ const TimeSpanLabel = ({ begin, end, duration, totalDuration = duration }) => {
             ? (100 * (nEnd - nBegin)) / totalDuration
             : 100;
 
-    const [valStr, unitStr] = formatTime(duration);
-    const label = `\u0394${valStr}${unitStr.replace('u', '\u00B5')}`;
+    const label = `\u0394${formatDuration(duration)}`;
 
     return (
         <div

--- a/src/components/Chart/statbox.scss
+++ b/src/components/Chart/statbox.scss
@@ -37,6 +37,7 @@
         margin-bottom: -1px;
 
         .value {
+            white-space: nowrap;
             font-size: 20px;
             height: 28px;
             .unit {

--- a/src/utils/duration.jsx
+++ b/src/utils/duration.jsx
@@ -1,0 +1,156 @@
+/* Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+
+export const formatDuration = microseconds => {
+    const usec = Math.floor(microseconds);
+    const u = `${usec % 1000}`;
+
+    if (usec < 1000) return `${u}\u00B5s`;
+
+    const t = new Date(Math.floor(usec / 1000));
+    const z = `${t.getUTCMilliseconds()}`;
+    if (usec < 10000) return `${z}.${u.padStart(3, '0')}ms`;
+    if (usec < 100000) return `${z}.${u.padStart(3, '0').substr(0, 2)}ms`;
+    if (usec < 1000000) return `${z}.${u.padStart(3, '0').substr(0, 1)}ms`;
+
+    const s = `${t.getUTCSeconds()}`;
+    if (usec < 10000000) return `${s}.${z.padStart(3, '0')}s`;
+    if (usec < 60000000) return `${s}.${z.padStart(3, '0').substr(0, 2)}s`;
+
+    const m = `${t.getUTCMinutes()}`;
+    if (usec < 600000000)
+        return `${m}:${s.padStart(2, '0')}.${z.padStart(3, '0').substr(0, 1)}s`;
+    if (usec < 3600000000) return `${m}:${s.padStart(2, '0')}s`;
+
+    const h = `${t.getUTCHours()}`;
+    if (usec < 86400000000)
+        return `${h}:${m.padStart(2, '0')}:${s.padStart(2, '0')}s`;
+
+    const d = Math.floor(usec / 86400000000);
+    return `${d}d ${h.padStart(2, '0')}:${m.padStart(2, '0')}`;
+};
+
+export const formatDurationHTML = microseconds => {
+    if (Number.isNaN(microseconds)) return null;
+    const usec = Math.floor(microseconds);
+    const u = `${usec % 1000}`;
+
+    if (usec < 1000)
+        return (
+            <div className="value">
+                {u}
+                <span className="unit">{'\u00B5s'}</span>
+            </div>
+        );
+    const t = new Date(Math.floor(usec / 1000));
+    const z = `${t.getUTCMilliseconds()}`;
+
+    if (usec < 10000)
+        return (
+            <div className="value">
+                {`${z}.${u.padStart(3, '0')}`}
+                <span className="unit">ms</span>
+            </div>
+        );
+    if (usec < 100000)
+        return (
+            <div className="value">
+                {`${z}.${u.padStart(3, '0').substr(0, 2)}`}
+                <span className="unit">ms</span>
+            </div>
+        );
+    if (usec < 1000000)
+        return (
+            <div className="value">
+                {`${z}.${u.padStart(3, '0').substr(0, 1)}`}
+                <span className="unit">ms</span>
+            </div>
+        );
+
+    const s = `${t.getUTCSeconds()}`;
+    if (usec < 10000000)
+        return (
+            <div className="value">
+                {`${s}.${z.padStart(3, '0')}`}
+                <span className="unit">s</span>
+            </div>
+        );
+    if (usec < 60000000)
+        return (
+            <div className="value">
+                {`${s}.${z.padStart(3, '0').substr(0, 2)}`}
+                <span className="unit">s</span>
+            </div>
+        );
+
+    const m = `${t.getUTCMinutes()}`;
+    if (usec < 600000000)
+        return (
+            <div className="value">
+                {`${m}:${s.padStart(2, '0')}.${z
+                    .padStart(3, '0')
+                    .substr(0, 1)}`}
+                <span className="unit">s</span>
+            </div>
+        );
+    if (usec < 3600000000)
+        return (
+            <div className="value">
+                {`${m}:${s.padStart(2, '0')}`}
+                <span className="unit">s</span>
+            </div>
+        );
+
+    const h = `${t.getUTCHours()}`;
+    if (usec < 86400000000)
+        return (
+            <div className="value">
+                {`${h}:${m.padStart(2, '0')}:${s.padStart(2, '0')}`}
+                <span className="unit">s</span>
+            </div>
+        );
+
+    const d = Math.floor(usec / 86400000000);
+    return (
+        <div className="value">
+            {d}
+            <span className="unit">d</span>
+            {` ${h.padStart(2, '0')}:${m.padStart(2, '0')}`}
+        </div>
+    );
+};

--- a/src/utils/duration.jsx
+++ b/src/utils/duration.jsx
@@ -54,15 +54,15 @@ export const formatDuration = microseconds => {
 
     const m = `${t.getUTCMinutes()}`;
     if (usec < 600000000)
-        return `${m}:${s.padStart(2, '0')}.${z.padStart(3, '0').substr(0, 1)}s`;
-    if (usec < 3600000000) return `${m}:${s.padStart(2, '0')}s`;
+        return `${m}:${s.padStart(2, '0')}.${z.padStart(3, '0').substr(0, 1)}m`;
+    if (usec < 3600000000) return `${m}:${s.padStart(2, '0')}m`;
 
     const h = `${t.getUTCHours()}`;
     if (usec < 86400000000)
-        return `${h}:${m.padStart(2, '0')}:${s.padStart(2, '0')}s`;
+        return `${h}:${m.padStart(2, '0')}:${s.padStart(2, '0')}h`;
 
     const d = Math.floor(usec / 86400000000);
-    return `${d}d ${h.padStart(2, '0')}:${m.padStart(2, '0')}`;
+    return `${d}d ${h.padStart(2, '0')}:${m.padStart(2, '0')}h`;
 };
 
 export const formatDurationHTML = microseconds => {
@@ -125,14 +125,14 @@ export const formatDurationHTML = microseconds => {
                 {`${m}:${s.padStart(2, '0')}.${z
                     .padStart(3, '0')
                     .substr(0, 1)}`}
-                <span className="unit">s</span>
+                <span className="unit">m</span>
             </div>
         );
     if (usec < 3600000000)
         return (
             <div className="value">
                 {`${m}:${s.padStart(2, '0')}`}
-                <span className="unit">s</span>
+                <span className="unit">m</span>
             </div>
         );
 
@@ -141,7 +141,7 @@ export const formatDurationHTML = microseconds => {
         return (
             <div className="value">
                 {`${h}:${m.padStart(2, '0')}:${s.padStart(2, '0')}`}
-                <span className="unit">s</span>
+                <span className="unit">h</span>
             </div>
         );
 
@@ -151,6 +151,7 @@ export const formatDurationHTML = microseconds => {
             {d}
             <span className="unit">d</span>
             {` ${h.padStart(2, '0')}:${m.padStart(2, '0')}`}
+            <span className="unit">h</span>
         </div>
     );
 };


### PR DESCRIPTION
This PR implements better representation of durations.
In different time scales the duration has the following formatting:

```
123µs
1.234ms
12.34ms
123.4ms
1.234s
12.34s
2:03.4m
20:34m
3:25:45h
12d 10:17h
```

This is used by the time-span controls above and below the chart and the stat boxes below the chart.