### PR TITLE
Update Changelog for 3.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,14 +12,14 @@
     [older, first version of the Power Profiler Kit hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit)
     now triggers can also be set when using the new
     [Power Profiler Kit II (PPK2) hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2).
--   Only with the PPK2: Set a **pre- or post trigger** by moving the slider
-    above the graph, to shift the charted area, thus deciding how much time
-    before and after the trigger that is relevant.
+-   Only with the PPK2: Set a **pre or post trigger** by moving the slider above
+    the graph, to decide how much time before and after the trigger is relevant
+    and will be shown for the next trigger.
 -   Average sampling with a lower resolution: When interested in **examining
     power over a longer time span** you can lower the samples per second.
-    Sampling is still done at the full resolution, but they are automatically
-    averaged to decrease the storage size. The rate can be lowered as far as
-    only a sample per second, enabling sampling for days or even months.
+    Sampling is still done at the full resolution, but automatically averaged to
+    decrease the storage size. The rate can be lowered as far as only a sample
+    per second, enabling sampling for days or even months.
 -   Besides the existing CSV export: **Save** the current data in a format to
     **Load** it again later within the app, enabling sharing data and examining
     it at a later time.
@@ -31,7 +31,7 @@
     they were previously only shown for a time range of up to 3 seconds, now
     they are shown for up to 30 seconds).
 -   **Enhanced performance** to make the UI more responsive.
--   Several minor UI changes to improve the user experience
+-   Several **minor UI changes** to improve the user experience.
 
 ## Version 3.0.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,13 +4,17 @@
 
 -   Split the primary view in two, a **data logger** and a **real-time** view.
     With the data logger view the user can examine the power continuously over a
-    period of time. In the real-time view, which has similar functionality to an oscilloscope, the user can specify a trigger level, and when the consumed power reaches this threshold, the power consumption signature in the surrounding period of time can be inspected in detail.
+    period of time. In the real-time view, which has similar functionality to an
+    oscilloscope, the user can specify a trigger level, and when the consumed
+    power reaches this threshold, the power consumption signature in the
+    surrounding period of time can be inspected in detail.
 -   **Trigger**: Previously only available when using the
     [older, first version of the Power Profiler Kit hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit)
     now triggers can also be set when using the new
     [Power Profiler Kit II (PPK2) hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2).
--   Only with the PPK2: Set a **pre- or post trigger** by moving the slider above the
-    graph, to shift the charted area, thus deciding how much time before and after the trigger that is relevant.
+-   Only with the PPK2: Set a **pre- or post trigger** by moving the slider
+    above the graph, to shift the charted area, thus deciding how much time
+    before and after the trigger that is relevant.
 -   Average sampling with a lower resolution: When interested in **examining
     power over a longer time span** you can lower the samples per second.
     Sampling is still done at the full resolution, but they are automatically

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 -   **Trigger**: Previously only available when using the
     [older, first version of the Power Profiler Kit hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit)
     now triggers can also be set when using the new
-    [Power Profiler Kit II (PPK 2) hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2).
+    [Power Profiler Kit II (PPK2) hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2).
 -   Only with the PPK2: Set a **pre- or post trigger** by moving the slider above the
     graph, to shift the charted area, thus deciding how much time before and after the trigger that is relevant.
 -   Average sampling with a lower resolution: When interested in **examining

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,22 +1,51 @@
-## Unreleased
+## Version 3.1.0
+
 ### Added
-- Trigger function for PPK2
+
+-   For the different needs, created a **data logger** and a **real-time** tab.
+    With the data logger view you can examine the power continuously over a
+    short or long time. With the real-time view, you can view the power around a
+    defined trigger.
+-   **Trigger**: Previously only available when using the old
+    [older, first version of the Power Profiler Kit hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit)
+    now triggers can also be set when using the new
+    [Power Profiler Kit II (PPK 2) hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2).
+-   Only with the PPK2: Set a **pre trigger** by moving the slider above the
+    graph, to define how much time before and after the trigger you want to see.
+-   Average sampling with a lower resolution: When interested in **examining
+    power over a longer time span** you can lower the samples per second.
+    Sampling is still done at the full resolution, but they are automatically
+    averaged to decrease the storage size. The rate can be lowered as far as
+    only a sample per second, enabling sampling for days or even months.
+-   Besides the existing CSV export: **Save** the current data in a format to
+    **Load** it again later within the app, enabling sharing data and examining
+    it at a later time.
+-   Create easy **screenshots** of the current graph.
+
 ### Updates
-- Add screenshot functionality
-- Split real-time and data logger views
-- Enhanced performance to make the UI more responsive
-- Raise limit for displaying digital channels (on the highest resolution they were previously only shown for a time range of up to 3 seconds, now they are shown for up to 30 seconds).
+
+-   Raise **limit for displaying digital channels** (on the highest resolution
+    they were previously only shown for a time range of up to 3 seconds, now
+    they are shown for up to 30 seconds).
+-   **Enhanced performance** to make the UI more responsive.
 
 ## Version 3.0.2
+
 ## Fixed
-- The CSV export was exporting the wrong portion of data #123
+
+-   The CSV export was exporting the wrong portion of data #123
 
 ## Version 3.0.1
-## Fixed
-- Fix connecting PPK via J-Link Lite #122
-- Fix issue where moving the right handle past the left handle in the chart selection would break the values displayed in the selection window #119
 
+## Fixed
+
+-   Fix connecting PPK via J-Link Lite #122
+-   Fix issue where moving the right handle past the left handle in the chart
+    selection would break the values displayed in the selection window #119
 
 ## Version 3.0.0
+
 ### Changed
-- Complete rewrite of the application. This version supports the old power profiler kit, in addition to the newly released PPK2 hardware.
+
+-   Complete rewrite of the application. This version supports the old power
+    profiler kit, in addition to the newly released PPK2 hardware.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Power Profiler app for [nRF Connect](https://github.com/NordicSemiconductor/pc-n
 
 ## Introduction
 
-*nRF Connect Power Profiler* is a tool to communicate with the [Power Profiler Kit II (PPK 2)](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2), an affordable and flexible tool to obtain real-time current measurements of your designs. It also supports the [older, first version of the Power Profiler Kit](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit). The PPK measures current consumption for a connected Nordic Development Kit or any external board. It gives a detailed picture of the current profile for the user application.
+*nRF Connect Power Profiler* is a tool to communicate with the [Power Profiler Kit II (PPK2)](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2), an affordable and flexible tool to obtain real-time current measurements of your designs. It also supports the [older, first version of the Power Profiler Kit](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit). The PPK measures current consumption for a connected Nordic Development Kit or any external board. It gives a detailed picture of the current profile for the user application.
 
 All functionality is described in the [User Guide](https://infocenter.nordicsemi.com/topic/ug_ppk2/UG/ppk/PPK_user_guide_Intro.html) (If you use the first version of the hardware, there is a different [User Guide for the PPK 1](https://infocenter.nordicsemi.com/topic/ug_ppk/UG/ppk/PPK_user_guide_Intro.html)).
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
 # nRF Connect Power Profiler
 
-Power Profiler app for [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher).
+Power Profiler app for
+[nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher).
 
 ## Introduction
 
-*nRF Connect Power Profiler* is a tool to communicate with the [Power Profiler Kit II (PPK2)](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2), an affordable and flexible tool to obtain real-time current measurements of your designs. It also supports the [older, first version of the Power Profiler Kit](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit). The PPK measures current consumption for a connected Nordic Development Kit or any external board. It gives a detailed picture of the current profile for the user application.
+_nRF Connect Power Profiler_ is a tool to communicate with the
+[Power Profiler Kit II (PPK2)](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2),
+an affordable and flexible tool to obtain real-time current measurements of your
+designs. It also supports the
+[older, first version of the Power Profiler Kit](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit).
+The PPK measures current consumption for a connected Nordic Development Kit or
+any external board. It gives a detailed picture of the current profile for the
+user application.
 
-All functionality is described in the [User Guide](https://infocenter.nordicsemi.com/topic/ug_ppk2/UG/ppk/PPK_user_guide_Intro.html) (If you use the first version of the hardware, there is a different [User Guide for the PPK 1](https://infocenter.nordicsemi.com/topic/ug_ppk/UG/ppk/PPK_user_guide_Intro.html)).
+All functionality is described in the
+[User Guide](https://infocenter.nordicsemi.com/topic/ug_ppk2/UG/ppk/PPK_user_guide_Intro.html)
+(If you use the first version of the hardware, there is a different
+[User Guide for the PPK 1](https://infocenter.nordicsemi.com/topic/ug_ppk/UG/ppk/PPK_user_guide_Intro.html)).
 
 ![screenshot](resources/screenshot.png)
 
 ## Installation
 
-See the [InfoCenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrftools%2Fstruct%2Fnrftools_nrfconnect.html) pages for information on how to install the application.
+See the
+[InfoCenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrftools%2Fstruct%2Fnrftools_nrfconnect.html)
+pages for information on how to install the application.
 
 ## Development
 
-See the [app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/) pages for details on how to develop apps for the nRF Connect for Desktop framework.
+See the
+[app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/)
+pages for details on how to develop apps for the nRF Connect for Desktop
+framework.
 
 ## Feedback
 
@@ -24,7 +40,9 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 
 ## Contributing
 
-See the [infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing) for details.
+See the
+[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+for details.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ppk",
-  "version": "3.1.0-alpha.2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ppk",
-  "version": "3.1.0-alpha.2",
+  "version": "3.1.0",
   "description": "Power Profiler",
   "displayName": "Power Profiler",
   "repository": {


### PR DESCRIPTION
Explain the changes for 3.1.0. 

This is a bit more elaborate than other changelogs, because the release does change the PPK app quite a bit, so I think it is helpful to explain these to the users and also guide them a bit, e.g. on how to set pre and post triggering.

Some other things also changed:

- Bump the version to 3.1.0
- Reformat README.md
- We sometimes called the new device PPK 2 (with a space) other times PPK2. On https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2 it is also called PPK2 so this unifies the name to the one without a space.