### PR TITLE
Revert Power Cycle button

### DIFF
--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -470,10 +470,16 @@ export function setDeviceRunning(isRunning) {
 
 export function setPowerMode(isSmuMode) {
     return async dispatch => {
-        await device.ppkSetPowerMode(isSmuMode ? 2 : 1);
         logger.info(`Mode: ${isSmuMode ? 'Source meter' : 'Ampere meter'}`);
-        dispatch(setPowerModeAction(isSmuMode));
-        dispatch(setDeviceRunning(!isSmuMode));
+        if (isSmuMode) {
+            dispatch(setDeviceRunning(false));
+            await device.ppkSetPowerMode(true); // set to source mode
+            dispatch(setPowerModeAction(true));
+        } else {
+            await device.ppkSetPowerMode(true); // set to ampere mode
+            dispatch(setPowerModeAction(false));
+            dispatch(setDeviceRunning(true));
+        }
     };
 }
 

--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -473,7 +473,7 @@ export function setPowerMode(isSmuMode) {
         await device.ppkSetPowerMode(isSmuMode ? 2 : 1);
         logger.info(`Mode: ${isSmuMode ? 'Source meter' : 'Ampere meter'}`);
         dispatch(setPowerModeAction(isSmuMode));
-        if (!isSmuMode) dispatch(setDeviceRunning(true));
+        dispatch(setDeviceRunning(!isSmuMode));
     };
 }
 

--- a/src/components/SidePanel/PowerMode.jsx
+++ b/src/components/SidePanel/PowerMode.jsx
@@ -62,23 +62,7 @@ export default () => {
 
     const togglePowerMode = () => dispatch(setPowerMode(!isSmuMode));
 
-    const powerCycle = () => {
-        dispatch(setDeviceRunning(false));
-        setTimeout(() => {
-            dispatch(setDeviceRunning(true));
-        }, 20);
-    };
-
     const isRunning = samplingRunning || triggerRunning || triggerSingleWaiting;
-
-    const powerToggleVisible =
-        capabilities.ppkDeviceRunning &&
-        (isSmuMode || !capabilities.ppkSetPowerMode);
-
-    const powerCycleButtonVisible =
-        capabilities.ppkDeviceRunning &&
-        capabilities.ppkSetPowerMode &&
-        !isSmuMode;
 
     return (
         <Group heading={`${capabilities.ppkSetPowerMode ? 'Mode' : ''}`}>
@@ -109,7 +93,7 @@ export default () => {
                 </ButtonGroup>
             )}
             <VoltageRegulator />
-            {powerToggleVisible && (
+            {capabilities.ppkDeviceRunning && (
                 <Toggle
                     title="Turn power on/off for device under test"
                     onToggle={() => dispatch(setDeviceRunning(!deviceRunning))}
@@ -119,16 +103,6 @@ export default () => {
                     barColorToggled={nordicBlue}
                     variant="secondary"
                 />
-            )}
-            {powerCycleButtonVisible && (
-                <Button
-                    title="Turn power off and on again for device under test"
-                    variant="set"
-                    className="w-100 secondary-btn"
-                    onClick={powerCycle}
-                >
-                    Power cycle
-                </Button>
             )}
         </Group>
     );

--- a/src/device/serialDevice.js
+++ b/src/device/serialDevice.js
@@ -325,8 +325,8 @@ class SerialDevice extends Device {
 
     // Capability methods
 
-    ppkSetPowerMode(...args) {
-        return this.sendCommand([PPKCmd.SetPowerMode, ...args]);
+    ppkSetPowerMode(isSmuMode) {
+        return this.sendCommand([PPKCmd.SetPowerMode, isSmuMode ? 2 : 1]);
     }
 
     ppkSetUserGains(range, gain) {


### PR DESCRIPTION
Revert back to using the Enable Power Output toggle for Ampere mode also.

Also change we the default power mode to OFF for Source mode and 
ON for Ampere mode