### PR TITLE
Trigger level adjusting issues for both ppk devices

### DIFF
--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -561,6 +561,7 @@ export function switchingPointsReset() {
 export function updateTriggerLevel(triggerLevel) {
     return async (dispatch, getState) => {
         dispatch(triggerLevelSetAction(triggerLevel));
+        if (!device.capabilities.hwTrigger) return;
 
         const { triggerSingleWaiting, triggerRunning } = getState().app.trigger;
         const high = (triggerLevel >> 16) & 0xff;

--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -564,16 +564,13 @@ export function updateTriggerLevel(triggerLevel) {
         if (!device.capabilities.hwTrigger) return;
 
         const { triggerSingleWaiting, triggerRunning } = getState().app.trigger;
-        const high = (triggerLevel >> 16) & 0xff;
-        const mid = (triggerLevel >> 8) & 0xff;
-        const low = triggerLevel & 0xff;
 
         if (triggerSingleWaiting) {
             logger.info(`Trigger level updated to ${triggerLevel} \u00B5A`);
-            await device.ppkTriggerSingleSet(high, mid, low);
+            await device.ppkTriggerSingleSet(triggerLevel);
         } else if (triggerRunning) {
             logger.info(`Trigger level updated to ${triggerLevel} \u00B5A`);
-            await device.ppkTriggerSet(high, mid, low);
+            await device.ppkTriggerSet(triggerLevel);
         }
     };
 }

--- a/src/device/rttDevice.js
+++ b/src/device/rttDevice.js
@@ -139,6 +139,7 @@ class RTTDevice extends Device {
 
         this.capabilities.maxContinuousSamplingTimeUs = 130;
         this.capabilities.samplingTimeUs = this.adcSamplingTimeUs;
+        this.capabilities.hwTrigger = true;
         this.serialNumber = parseInt(device.serialNumber, 10);
         this.isRttOpen = false;
 


### PR DESCRIPTION
This PR addresses two separate issues with adjusting trigger level, one for PPK1 and one for PPK2.

accf952: Currently we send commands to start averaging to the PPK2 device when adjusting trigger level. This is not necessary and seems to potentially put the device in a bad state where it starts blinking red and stops sending samples.

7119dbc: PPK1 only. Trigger level is not properly adjusted while triggering. Currently we are passing the wrong arguments to `ppkTriggerSet` and `ppkTriggerSingleSet` so update this.