### PR TITLE
Fix/trigger performance issues

### DIFF
--- a/src/actions/__tests__/triggerActions-test.js
+++ b/src/actions/__tests__/triggerActions-test.js
@@ -46,7 +46,7 @@ const mockStore = configureMockStore(middlewares);
 const mockDevicePPK1 = {
     ppkTriggerStop: jest.fn(),
     capabilities: {
-        prePostTriggering: false,
+        hwTrigger: true,
     },
 };
 

--- a/src/actions/__tests__/triggerActions-test.js
+++ b/src/actions/__tests__/triggerActions-test.js
@@ -276,18 +276,17 @@ const getExpectedChartActionsPPK2 = (fromIndex, toIndex, shift = 0) => {
     const from = indexToTimestamp(fromIndex - shift);
     const to = indexToTimestamp(toIndex - shift);
     return [
-        { type: 'CHART_WINDOW_UNLOCK' },
         {
-            type: 'CHART_WINDOW',
+            type: 'CHART_TRIGGER_WINDOW',
             windowBegin: from,
             windowEnd: to,
             windowDuration: to - from,
-            yMax: undefined,
-            yMin: undefined,
         },
-        { type: 'CHART_WINDOW_LOCK' },
-        { type: 'SET_TRIGGER_ORIGIN', origin: fromIndex },
-        { type: 'SET_TRIGGER_START', triggerStartIndex: null },
+        {
+            type: 'TRIGGER_COMPLETE',
+            origin: fromIndex,
+            triggerStartIndex: null,
+        },
     ];
 };
 
@@ -295,16 +294,12 @@ const getExpectedChartActionsPPK1 = (fromIndex, toIndex) => {
     const from = indexToTimestamp(fromIndex);
     const to = indexToTimestamp(toIndex);
     return [
-        { type: 'CHART_WINDOW_UNLOCK' },
         {
-            type: 'CHART_WINDOW',
+            type: 'CHART_TRIGGER_WINDOW',
             windowBegin: from,
             windowEnd: to,
             windowDuration: to - from,
-            yMax: undefined,
-            yMin: undefined,
         },
-        { type: 'CHART_WINDOW_LOCK' },
         { type: 'SET_TRIGGER_START', triggerStartIndex: null },
     ];
 };

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -40,8 +40,8 @@ import { indexToTimestamp } from '../globals';
 import { chartTriggerWindowAction } from '../reducers/chartReducer';
 import {
     clearSingleTriggerWaitingAction,
-    setTriggerStartAction,
     completeTriggerAction,
+    setTriggerStartAction,
 } from '../reducers/triggerReducer';
 
 // PPK2 trigger point should by default be shifted to middle of window

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -40,8 +40,8 @@ import { indexToTimestamp } from '../globals';
 import { chartTriggerWindowAction } from '../reducers/chartReducer';
 import {
     clearSingleTriggerWaitingAction,
-    setTriggerOriginAction,
     setTriggerStartAction,
+    completeTriggerAction,
 } from '../reducers/triggerReducer';
 
 // PPK2 trigger point should by default be shifted to middle of window
@@ -109,9 +109,8 @@ export function processTriggerSample(currentValue, device, samplingData) {
         const from = indexToTimestamp(triggerStartIndex - shiftedIndex);
         const to = indexToTimestamp(currentIndex - shiftedIndex);
         dispatch(chartTriggerWindowAction(from, to, to - from));
-        if (!isPPK1) {
-            dispatch(setTriggerOriginAction(triggerStartIndex));
-        }
-        dispatch(setTriggerStartAction(null));
+        isPPK1
+            ? dispatch(setTriggerStartAction(null))
+            : dispatch(completeTriggerAction(triggerStartIndex));
     };
 }

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -77,7 +77,7 @@ export function processTriggerSample(currentValue, device, samplingData) {
             },
         } = getState().app;
 
-        const isPPK1 = !device.capabilities.prePostTriggering; // hwTrigger
+        const isPPK1 = !!device.capabilities.hwTrigger;
 
         if (!triggerStartIndex) {
             if (currentValue >= triggerLevel || isPPK1) {

--- a/src/actions/triggerActions.js
+++ b/src/actions/triggerActions.js
@@ -37,11 +37,7 @@
 import { logger } from 'pc-nrfconnect-shared';
 
 import { indexToTimestamp } from '../globals';
-import {
-    chartWindowAction,
-    chartWindowLockAction,
-    chartWindowUnLockAction,
-} from '../reducers/chartReducer';
+import { chartTriggerWindowAction } from '../reducers/chartReducer';
 import {
     clearSingleTriggerWaitingAction,
     setTriggerOriginAction,
@@ -81,7 +77,7 @@ export function processTriggerSample(currentValue, device, samplingData) {
             },
         } = getState().app;
 
-        const isPPK1 = !device.capabilities.prePostTriggering;
+        const isPPK1 = !device.capabilities.prePostTriggering; // hwTrigger
 
         if (!triggerStartIndex) {
             if (currentValue >= triggerLevel || isPPK1) {
@@ -96,7 +92,6 @@ export function processTriggerSample(currentValue, device, samplingData) {
             ? endOfTrigger
             : (triggerStartIndex + windowSize) % dataBuffer.length <=
               currentIndex;
-
         if (!enoughSamplesCollected) return;
 
         if (triggerSingleWaiting) {
@@ -113,9 +108,7 @@ export function processTriggerSample(currentValue, device, samplingData) {
         );
         const from = indexToTimestamp(triggerStartIndex - shiftedIndex);
         const to = indexToTimestamp(currentIndex - shiftedIndex);
-        dispatch(chartWindowUnLockAction());
-        dispatch(chartWindowAction(from, to, to - from));
-        dispatch(chartWindowLockAction());
+        dispatch(chartTriggerWindowAction(from, to, to - from));
         if (!isPPK1) {
             dispatch(setTriggerOriginAction(triggerStartIndex));
         }

--- a/src/reducers/triggerReducer.js
+++ b/src/reducers/triggerReducer.js
@@ -60,6 +60,7 @@ export const SET_TRIGGER_START = 'SET_TRIGGER_START';
 export const SET_WINDOW_OFFSET = 'SET_WINDOW_OFFSET';
 export const SET_TRIGGER_ORIGIN = 'SET_TRIGGER_ORIGIN';
 export const LOAD_TRIGGER_STATE = 'LOAD_TRIGGER_STATE';
+export const TRIGGER_COMPLETE = 'TRIGGER_COMPLETE';
 
 export const triggerLevelSetAction = triggerLevel => ({
     type: TRIGGER_LEVEL_SET,
@@ -107,6 +108,12 @@ export const setTriggerOriginAction = origin => ({
 export const setTriggerState = state => ({
     type: LOAD_TRIGGER_STATE,
     ...state,
+});
+
+export const completeTriggerAction = origin => ({
+    type: TRIGGER_COMPLETE,
+    origin,
+    triggerStartIndex: null,
 });
 
 export default (state = initialState, { type, ...action }) => {
@@ -166,6 +173,13 @@ export default (state = initialState, { type, ...action }) => {
         }
         case SET_TRIGGER_ORIGIN: {
             return { ...state, triggerOrigin: action.origin };
+        }
+        case TRIGGER_COMPLETE: {
+            return {
+                ...state,
+                triggerOrigin: action.origin,
+                triggerStartIndex: action.triggerStartIndex,
+            };
         }
         case LOAD_TRIGGER_STATE: {
             return { ...state, ...action };


### PR DESCRIPTION
The reason for this PR is that if the users sets the trigger level to 1 uA, the performance degrades so bad the app basically becomes unusable. After some trial and error, I found some changes that alleviates this at least slightly, there are probably more elegant and effective improvements available, this is just meant as a starting point.