### PR TITLE
Ceil xMax to ensure that we don't get off by 1us error when zooming

### DIFF
--- a/src/components/Chart/plugins/chart.zoomPan.js
+++ b/src/components/Chart/plugins/chart.zoomPan.js
@@ -125,7 +125,7 @@ const processWheelEvents = () => {
             return;
         }
         const p = xScale.getValueForPixel(clientX - xOffset);
-        zoomAtOrigin(callback, p, z, xMin, xMax);
+        zoomAtOrigin(callback, p, z, xMin, Math.ceil(xMax));
     }
 };
 


### PR DESCRIPTION
![zoom-out-issue](https://user-images.githubusercontent.com/72191781/106889141-e4fa0080-66e7-11eb-89b6-b724addf8c4a.gif)

When zooming in and out in the real time view (probably the same happens in the data logger view, but it's much less consequential) the zoom-out sometimes stops 1us off the total window duration. And then we cannot zoom out any more, meaning that the trigger handle to shift the window is not accessible as it will be hidden while zooming. 

This proposed fix will just ensure that the `xMax` value is rounded up. The numbers involved are so big that a decimal rounding should have minimal effect.