### PR TITLE
Invert bit sequence when exporting data.

### DIFF
--- a/src/actions/__tests__/exportChartAction-test.js
+++ b/src/actions/__tests__/exportChartAction-test.js
@@ -91,7 +91,6 @@ describe('formatData', () => {
         // Test that we only get timestamp and current
         expect(content).toMatch(/0\.02,7\.000,11111111,1,1,1,1,1,1,1,1/);
         expect(content).toMatch(/0\.03,8\.000,00000000,0,0,0,0,0,0,0,0\s/);
-        // 69 to binary = 01000101
-        expect(content).toMatch(/0\.04,9\.000,01000101,0,1,0,0,0,1,0,1\s/);
+        expect(content).toMatch(/0\.04,9\.000,10100010,1,0,1,0,0,0,1,0\s/);
     });
 });

--- a/src/actions/exportChartAction.js
+++ b/src/actions/exportChartAction.js
@@ -74,9 +74,7 @@ export const formatDataForExport = (
             if (bitsData) {
                 const bitstring = dc.map(
                     (_, i) =>
-                        ['-', '0', '1', 'X'][
-                            averagedBitState(bitsData[k], 7 - i)
-                        ]
+                        ['-', '0', '1', 'X'][averagedBitState(bitsData[k], i)]
                 );
                 content += selectivePrint(
                     [


### PR DESCRIPTION
Currently the bit sequence is inverted, i.e. the bit representing channel D0 is in the last position and D7 is in the first position. So we need to fix this to display it properly in the exported CSV files.

