### PR TITLE
Fix/chart issues when loading ppk

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,61 +1,67 @@
+## Version 3.1.2
+
+## Fixed
+
+- Chart issues when loading from saved capture file #198
+
 ## Version 3.1.1
 
 ## Fixed
 
--   CSV export had an inverted bit sequence #192
+- CSV export had an inverted bit sequence #192
 
 ## Version 3.1.0
 
 ### Added
 
--   Split the primary view in two, a **data logger** and a **real-time** view.
+- Split the primary view in two, a **data logger** and a **real-time** view.
     With the data logger view the user can examine the power continuously over a
     period of time. In the real-time view, which has similar functionality to an
     oscilloscope, the user can specify a trigger level, and when the consumed
     power reaches this threshold, the power consumption signature in the
     surrounding period of time can be inspected in detail.
--   **Trigger**: Previously only available when using the
+- **Trigger**: Previously only available when using the
     [older, first version of the Power Profiler Kit hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit)
     now triggers can also be set when using the new
     [Power Profiler Kit II (PPK2) hardware](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit-2).
--   Only with the PPK2: Set a **pre or post trigger** by moving the slider above
+- Only with the PPK2: Set a **pre or post trigger** by moving the slider above
     the graph, to decide how much time before and after the trigger is relevant
     and will be shown for the next trigger.
--   Average sampling with a lower resolution: When interested in **examining
+- Average sampling with a lower resolution: When interested in **examining
     power over a longer time span** you can lower the samples per second.
     Sampling is still done at the full resolution, but automatically averaged to
     decrease the storage size. The rate can be lowered as far as only a sample
     per second, enabling sampling for days or even months.
--   Besides the existing CSV export: **Save** the current data in a format to
+- Besides the existing CSV export: **Save** the current data in a format to
     **Load** it again later within the app, enabling sharing data and examining
     it at a later time.
--   Easily create **screenshots** of the current graph.
+- Easily create **screenshots** of the current graph.
 
 ### Updates
 
--   Raise **limit for displaying digital channels** (on the highest resolution
+- Raise **limit for displaying digital channels** (on the highest resolution
     they were previously only shown for a time range of up to 3 seconds, now
     they are shown for up to 30 seconds).
--   **Enhanced performance** to make the UI more responsive.
--   Several **minor UI changes** to improve the user experience.
+- **Enhanced performance** to make the UI more responsive.
+- Several **minor UI changes** to improve the user experience.
 
 ## Version 3.0.2
 
 ## Fixed
 
--   CSV export contained the wrong portion of data #123
+- CSV export contained the wrong portion of data #123
 
 ## Version 3.0.1
 
 ## Fixed
 
--   Connecting a PPK via J-Link Lite failed #122
--   Moving the right handle past the left handle in the chart selection would
+- Connecting a PPK via J-Link Lite failed #122
+- Moving the right handle past the left handle in the chart selection would
     break the values displayed in the selection window #119
 
 ## Version 3.0.0
 
 ### Changed
 
--   Complete rewrite of the application. This version supports the old power
+- Complete rewrite of the application. This version supports the old power
     profiler kit, in addition to the newly released PPK2 hardware.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ppk",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ppk",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Power Profiler",
   "displayName": "Power Profiler",
   "repository": {

--- a/src/actions/fileActions.js
+++ b/src/actions/fileActions.js
@@ -46,6 +46,7 @@ import {
 import { options, updateTitle } from '../globals';
 import { setFileLoadedAction } from '../reducers/appReducer';
 import { setChartState } from '../reducers/chartReducer';
+import { setDataLoggerState } from '../reducers/dataLoggerReducer';
 import { setTriggerState } from '../reducers/triggerReducer';
 import loadData from '../utils/loadFileHandler';
 import { paneName } from '../utils/panes';
@@ -75,6 +76,7 @@ export const save = () => async (_, getState) => {
             options: { ...opts, currentPane: currentPaneSelector(getState()) },
             chartState: getState().app.chart,
             triggerState: getState().app.trigger,
+            dataLoggerState: getState().app.dataLogger,
         },
     };
 
@@ -106,6 +108,7 @@ export const load = () => async dispatch => {
     const {
         chartState,
         triggerState,
+        dataLoggerState,
         options: { currentPane, ...loadedOptions },
     } = metadata;
 
@@ -115,6 +118,9 @@ export const load = () => async dispatch => {
 
     dispatch(setChartState(chartState));
     dispatch(setFileLoadedAction(true));
+    if (dataLoggerState !== null) {
+        dispatch(setDataLoggerState(dataLoggerState));
+    }
     if (triggerState !== null) {
         dispatch(setTriggerState(triggerState));
     }

--- a/src/reducers/chartReducer.js
+++ b/src/reducers/chartReducer.js
@@ -191,8 +191,6 @@ export const resetCursorAndChart = () => (dispatch, getState) => {
 export const setChartState = state => ({
     type: LOAD_CHART_STATE,
     ...state,
-    yMin: null,
-    yMax: null,
     hasDigitalChannels: options.bits !== null,
 });
 

--- a/src/reducers/dataLoggerReducer.js
+++ b/src/reducers/dataLoggerReducer.js
@@ -60,6 +60,7 @@ const initialState = {
 const DL_SAMPLE_FREQ_LOG_10 = 'DL_SAMPLE_FREQ_LOG_10';
 const DL_DURATION_SECONDS = 'DL_DURATION_SECONDS';
 const SET_SAMPLING_ATTRS = 'SET_SAMPLING_ATTRS';
+const SET_DATA_LOGGER_STATE = 'SET_DATA_LOGGER_STATE';
 
 export const updateSampleFreqLog10 = sampleFreqLog10 => ({
     type: DL_SAMPLE_FREQ_LOG_10,
@@ -75,6 +76,11 @@ export const updateDurationSeconds = durationSeconds => ({
 export const setSamplingAttrsAction = maxContinuousSamplingTimeUs => ({
     type: SET_SAMPLING_ATTRS,
     maxContinuousSamplingTimeUs,
+});
+
+export const setDataLoggerState = state => ({
+    type: SET_DATA_LOGGER_STATE,
+    ...state,
 });
 
 export default (state = initialState, { type, ...action }) => {
@@ -139,6 +145,9 @@ export default (state = initialState, { type, ...action }) => {
                 `durationSeconds-${state.maxSampleFreq}`,
                 action.durationSeconds
             );
+            return { ...state, ...action };
+        }
+        case SET_DATA_LOGGER_STATE: {
             return { ...state, ...action };
         }
         default:


### PR DESCRIPTION
This PR should fix issue [#198](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/issues/198).

It contains two fixes:
- d9a1246: Add `dataLoggerState` to the saved `.ppk`  file.
- 3e60fa9: `yMin` and `yMax` was set to `null` for historic reasons, but this is no longer required, so we can now use correct values for these.