### PR TITLE
Implement option to adjust buffer size

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Changed
+- Advanced option to adjust buffer size is now available, which enables longer sampling time.
+    - Enter advanced options by pressing `ctrl+alt+shift+a`.
+
 ## 3.2.1 - 2021-11-30
 
 ### Fixed

--- a/src/components/SidePanel/BufferSettings.jsx
+++ b/src/components/SidePanel/BufferSettings.jsx
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
 import React from 'react';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';

--- a/src/components/SidePanel/BufferSettings.jsx
+++ b/src/components/SidePanel/BufferSettings.jsx
@@ -22,12 +22,12 @@ export const BufferSettings = () => {
     return (
         <>
             <CollapsibleGroup
-                heading="Buffer Settings"
-                title="Increase size of buffer to increase the memory usage for sampling."
+                heading="Sampling Buffer"
+                title="Adjust max buffer size for sampling."
             >
                 <Form.Label
                     htmlFor="slider-ram-size"
-                    title="Increase max size of buffer to sample for longer."
+                    title="Increase to sample for longer, decrease to solve performance issues."
                 >
                     <span className="flex-fill">Max size of buffer</span>
                     <NumberInlineInput

--- a/src/components/SidePanel/BufferSettings.jsx
+++ b/src/components/SidePanel/BufferSettings.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Form from 'react-bootstrap/Form';
+import { useDispatch, useSelector } from 'react-redux';
+import { CollapsibleGroup, NumberInlineInput } from 'pc-nrfconnect-shared';
+
+import {
+    changeMaxBufferSizeAction,
+    maxBufferSize as maxBufferSizeSelector,
+} from '../../reducers/dataLoggerReducer';
+
+export const BufferSettings = () => {
+    const maxBufferSize = useSelector(maxBufferSizeSelector);
+    const dispatch = useDispatch();
+    const range = { min: 173, max: Infinity };
+
+    return (
+        <>
+            <CollapsibleGroup
+                heading="Buffer Settings"
+                title="Increase size of buffer to increase the memory usage for sampling."
+            >
+                <Form.Label
+                    htmlFor="slider-ram-size"
+                    title="Increase max size of buffer to sample for longer."
+                >
+                    <span className="flex-fill">Max size of buffer</span>
+                    <NumberInlineInput
+                        value={maxBufferSize}
+                        range={range}
+                        onChange={newValue =>
+                            dispatch(changeMaxBufferSizeAction(newValue))
+                        }
+                    />
+                    <span> MB</span>
+                </Form.Label>
+            </CollapsibleGroup>
+        </>
+    );
+};

--- a/src/components/SidePanel/BufferSettings.jsx
+++ b/src/components/SidePanel/BufferSettings.jsx
@@ -17,29 +17,27 @@ import {
 export const BufferSettings = () => {
     const maxBufferSize = useSelector(maxBufferSizeSelector);
     const dispatch = useDispatch();
-    const range = { min: 173, max: Infinity };
+    const range = { min: 1, max: Infinity };
 
     return (
-        <>
-            <CollapsibleGroup
-                heading="Sampling Buffer"
-                title="Adjust max buffer size for sampling."
+        <CollapsibleGroup
+            heading="Sampling Buffer"
+            title="Adjust max buffer size for sampling."
+        >
+            <Form.Label
+                htmlFor="slider-ram-size"
+                title="Increase to sample for longer, decrease to solve performance issues."
             >
-                <Form.Label
-                    htmlFor="slider-ram-size"
-                    title="Increase to sample for longer, decrease to solve performance issues."
-                >
-                    <span className="flex-fill">Max size of buffer</span>
-                    <NumberInlineInput
-                        value={maxBufferSize}
-                        range={range}
-                        onChange={newValue =>
-                            dispatch(changeMaxBufferSizeAction(newValue))
-                        }
-                    />
-                    <span> MB</span>
-                </Form.Label>
-            </CollapsibleGroup>
-        </>
+                <span className="flex-fill">Max size of buffer</span>
+                <NumberInlineInput
+                    value={maxBufferSize}
+                    range={range}
+                    onChange={newValue =>
+                        dispatch(changeMaxBufferSizeAction(newValue))
+                    }
+                />
+                <span> MB</span>
+            </Form.Label>
+        </CollapsibleGroup>
     );
 };

--- a/src/components/SidePanel/NumberWithUnitInput.jsx
+++ b/src/components/SidePanel/NumberWithUnitInput.jsx
@@ -30,7 +30,10 @@ const NumberWithUnit = ({
         onChange(n * multiplier);
     };
 
-    useEffect(() => setInternalValue(value / multiplier), [multiplier, value]);
+    useEffect(
+        () => setInternalValue(Math.round(value / multiplier)),
+        [multiplier, value]
+    );
 
     return (
         <div

--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -16,6 +16,7 @@ import {
     toggleAdvancedModeAction,
 } from '../../reducers/appReducer';
 import { isDataLoggerPane, isRealTimePane } from '../../utils/panes';
+import { BufferSettings } from './BufferSettings';
 import DisplayOptions from './DisplayOptions';
 import Gains from './Gains';
 import Instructions from './Instructions';
@@ -80,6 +81,7 @@ export default () => {
                     <ResistorCalibration />
                     <Gains />
                     <SpikeFilter />
+                    <BufferSettings />
                 </>
             )}
         </SidePanel>

--- a/src/reducers/dataLoggerReducer.js
+++ b/src/reducers/dataLoggerReducer.js
@@ -38,7 +38,8 @@ const getAdjustedRanges = (maxBufferSize, ranges) => {
     });
 };
 
-const initialMaxBufferSize = getMaxBufferSize(173);
+// Default max buffer size 200MB
+const initialMaxBufferSize = getMaxBufferSize(200);
 const initialRanges = getAdjustedRanges(initialMaxBufferSize, [
     { name: 'days', multiplier: 24 * 60 * 60, min: 7, max: 500, frequency: 1 }, // 1Hz
     { name: 'days', multiplier: 24 * 60 * 60, min: 1, max: 50, frequency: 10 }, // 10Hz

--- a/src/reducers/dataLoggerReducer.js
+++ b/src/reducers/dataLoggerReducer.js
@@ -19,13 +19,13 @@ import {
  * [Get ranges with max field adjusted for the current maxBufferSize]
  * @param {Number} maxBufferSize []
  * @param {Object} ranges []
- * @returns {Object} [with max field adjusted for max sampling buffer size]
+ * @returns {Array} [with max field adjusted for max sampling buffer size]
  */
 const getAdjustedRanges = (maxBufferSize, ranges) => {
     // Maximum number of elements that the current maxBufferSize could initialize.
-    const bytesPerElement = 4;
+    const BYTES_PER_ELEMENT = 4;
     const maxNumberOfElements = Math.floor(
-        unit(maxBufferSize, 'MB').to('byte').toNumber() / bytesPerElement
+        unit(maxBufferSize, 'MB').to('byte').toNumber() / BYTES_PER_ELEMENT
     );
 
     return ranges.map(range => {
@@ -160,15 +160,14 @@ export default (state = initialState, { type, ...action }) => {
         case MAX_BUFFER_SIZE: {
             const { range } = state;
             const { maxBufferSize } = action;
-            let { ranges, durationSeconds } = state;
+            const { ranges, durationSeconds } = state;
 
-            ranges = getAdjustedRanges(maxBufferSize, ranges);
-            durationSeconds =
-                durationSeconds < range.max ? durationSeconds : range.max;
+            const newRanges = getAdjustedRanges(maxBufferSize, ranges);
+            const newDurationSeconds = Math.min(range.max, durationSeconds);
 
             persistDuration(state.maxSampleFreq, durationSeconds);
             persistMaxBufferSize(maxBufferSize);
-            return { ...state, ranges, maxBufferSize, durationSeconds };
+            return { ...state, newRanges, maxBufferSize, newDurationSeconds };
         }
         default:
             return state;

--- a/src/reducers/dataLoggerReducer.js
+++ b/src/reducers/dataLoggerReducer.js
@@ -8,8 +8,10 @@ import { unit } from 'mathjs';
 
 import {
     getDuration,
+    getMaxBufferSize,
     getSampleFreq,
     setDuration as persistDuration,
+    setMaxBufferSize as persistMaxBufferSize,
     setSampleFreq as persistSampleFreq,
 } from '../utils/persistentStore';
 
@@ -39,7 +41,7 @@ const initialState = {
     durationSeconds: 300,
     ranges: initialRanges,
     range: initialRanges[initialFreqLog10],
-    maxBufferSize: 173,
+    maxBufferSize: getMaxBufferSize(173),
 };
 
 const DL_SAMPLE_FREQ_LOG_10 = 'DL_SAMPLE_FREQ_LOG_10';
@@ -150,7 +152,7 @@ export default (state = initialState, { type, ...action }) => {
                     numberOfElements / (multiplier * frequency)
                 );
             });
-
+            persistMaxBufferSize(maxBufferSize);
             return { ...state, ranges, maxBufferSize };
         }
         default:

--- a/src/reducers/dataLoggerReducer.js
+++ b/src/reducers/dataLoggerReducer.js
@@ -28,14 +28,14 @@ const getAdjustedRanges = (maxBufferSize, ranges) => {
         unit(maxBufferSize, 'MB').to('byte').toNumber() / bytesPerElement
     );
 
-    ranges.forEach((_range, index) => {
+    return ranges.map(range => {
         // Find out how many seconds, minutes, hours or days is required to fill the array with any given frequency.
-        const { multiplier, frequency } = _range;
-        ranges[index].max = Math.floor(
-            maxNumberOfElements / (multiplier * frequency)
-        );
+        const { multiplier, frequency } = range;
+        return {
+            ...range,
+            max: Math.floor(maxNumberOfElements / (multiplier * frequency)),
+        };
     });
-    return ranges;
 };
 
 const initialMaxBufferSize = getMaxBufferSize(173);

--- a/src/utils/persistentStore.js
+++ b/src/utils/persistentStore.js
@@ -56,3 +56,8 @@ export const getDuration = (maxSampleFreq, defaultValue) =>
     store().get(`durationSeconds-${maxSampleFreq}`, defaultValue);
 export const setDuration = (maxSampleFreq, durationSeconds) =>
     store().set(`durationSeconds-${maxSampleFreq}`, durationSeconds);
+
+export const getMaxBufferSize = defaultMaxBufferSize =>
+    store().get('maxBufferSize', defaultMaxBufferSize);
+export const setMaxBufferSize = maxBufferSize =>
+    store().set('maxBufferSize', maxBufferSize);


### PR DESCRIPTION
## Description
To allow users to sample for a longer time, they will also need to set aside more memory. This commit lets the customer sample for a longer period if they choose to increase max buffer size.

### Max size of buffer is persisted
You may find the option to change max size of buffer under the advanced settings panel by pressing `ctrl + alt + shift + a`.
![image](https://user-images.githubusercontent.com/34618612/144455606-537bc6ee-dd56-4b6c-a111-c7da51619622.png)

### Sampling Duration
Make sure that the sampling duration is changed only when required to. For example if the user should decrease the max size of buffer, then the sampling duration have to be below or equal to the new max sampling duration.
![image](https://user-images.githubusercontent.com/34618612/144450153-0c063ee4-0ffc-4f99-889f-590b51e405e4.png)

### Source of confusion
I noticed while working on this issue that the `Estimated RAM required` (image below), calculates the required memory from the size of the list that will be created before sampling. Is given the the user should know that this is only required for the sampling list, while the rest of the app will require additional memory to still run as normal? 
![image](https://user-images.githubusercontent.com/34618612/144450487-93e88b33-a2d3-4f34-8e8a-bb7757e077aa.png)
