### PR TITLE
Feat/cap voltage option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 ## Unreleased
 ### Changed
 - Advanced option to adjust buffer size is now available, which enables longer sampling time.
-    - Enter advanced options by pressing `ctrl+alt+shift+a`.
+- Advanced option to limit supply voltage under *Source Meter* now available.
+  - To display advanced options in the sidebar press `ctrl+alt+shift+a`.
 
 ## 3.2.1 - 2021-11-30
 

--- a/src/components/SidePanel/BufferSettings.jsx
+++ b/src/components/SidePanel/BufferSettings.jsx
@@ -22,11 +22,11 @@ export const BufferSettings = () => {
     return (
         <CollapsibleGroup
             heading="Sampling Buffer"
-            title="Adjust max buffer size for sampling."
+            title="Adjust max buffer size for sampling"
         >
             <Form.Label
                 htmlFor="slider-ram-size"
-                title="Increase to sample for longer, decrease to solve performance issues."
+                title="Increase to sample for longer, decrease to solve performance issues"
             >
                 <span className="flex-fill">Max size of buffer</span>
                 <NumberInlineInput

--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -27,6 +27,7 @@ import SpikeFilter from './SpikeFilter';
 import StartStop from './StartStop';
 import SwitchPoints from './SwitchPoints';
 import Trigger from './Trigger/Trigger';
+import { VoltageSettings } from './VoltageSettings';
 
 import './sidepanel.scss';
 
@@ -82,6 +83,7 @@ export default () => {
                     <Gains />
                     <SpikeFilter />
                     <BufferSettings />
+                    <VoltageSettings />
                 </>
             )}
         </SidePanel>

--- a/src/components/SidePanel/VoltageRegulator.jsx
+++ b/src/components/SidePanel/VoltageRegulator.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import BootstrapCollapse from 'react-bootstrap/Collapse';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';

--- a/src/components/SidePanel/VoltageRegulator.jsx
+++ b/src/components/SidePanel/VoltageRegulator.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import BootstrapCollapse from 'react-bootstrap/Collapse';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
@@ -19,13 +19,19 @@ import {
 
 const VoltageRegulator = () => {
     const dispatch = useDispatch();
-    const { vdd, min, max } = useSelector(voltageRegulatorState);
+    const { vdd, min, maxCap: max } = useSelector(voltageRegulatorState);
     const {
         isSmuMode,
         capabilities: { ppkSetPowerMode },
     } = useSelector(appState);
 
     const isVoltageSettable = !ppkSetPowerMode || isSmuMode;
+
+    useEffect(() => {
+        if (vdd > max) {
+            dispatch(moveVoltageRegulatorVddAction(max));
+        }
+    }, [vdd, max, dispatch]);
 
     return (
         <BootstrapCollapse in={isVoltageSettable}>

--- a/src/components/SidePanel/VoltageSettings.jsx
+++ b/src/components/SidePanel/VoltageSettings.jsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import Form from 'react-bootstrap/Form';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+    CollapsibleGroup,
+    NumberInlineInput,
+    Slider,
+} from 'pc-nrfconnect-shared';
+
+import {
+    updateVoltageRegulatorMaxCapAction,
+    voltageRegulatorState,
+} from '../../reducers/voltageRegulatorReducer';
+
+export const VoltageSettings = () => {
+    const { min, max, maxCap } = useSelector(voltageRegulatorState);
+    const dispatch = useDispatch();
+
+    return (
+        <CollapsibleGroup
+            heading="Voltage Limit"
+            title="Adjust to limit voltage supply"
+        >
+            <div
+                className="voltage-regulator"
+                title="Supply voltage above will be capped to the value set here"
+            >
+                <Form.Label htmlFor="slider-vdd">
+                    <span className="flex-fill">Set max supply voltage to</span>
+                    <NumberInlineInput
+                        value={maxCap}
+                        range={{ min, max }}
+                        onChange={value =>
+                            dispatch(updateVoltageRegulatorMaxCapAction(value))
+                        }
+                        onChangeComplete={() =>
+                            dispatch(updateVoltageRegulatorMaxCapAction(maxCap))
+                        }
+                    />{' '}
+                    mV
+                </Form.Label>
+                <Slider
+                    id="slider-vdd"
+                    values={[maxCap]}
+                    range={{ min, max }}
+                    onChange={[
+                        value =>
+                            dispatch(updateVoltageRegulatorMaxCapAction(value)),
+                    ]}
+                    onChangeComplete={() =>
+                        dispatch(updateVoltageRegulatorMaxCapAction(maxCap))
+                    }
+                />
+            </div>
+        </CollapsibleGroup>
+    );
+};

--- a/src/reducers/voltageRegulatorReducer.js
+++ b/src/reducers/voltageRegulatorReducer.js
@@ -4,14 +4,21 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import {
+    getVoltageRegulatorMaxCap,
+    setVoltageRegulatorMaxCap,
+} from '../utils/persistentStore';
+
 const initialState = {
     vdd: 3000, // [1800 .. 3600] mV
     currentVDD: 3000,
     min: 1850,
     max: 3600,
+    maxCap: getVoltageRegulatorMaxCap(3600),
 };
 
 const VOLTAGE_REGULATOR_UPDATED = 'VOLTAGE_REGULATOR_UPDATED';
+const VOLTAGE_REGULATOR_MAX_CAP_UPDATED = 'VOLTAGE_REGULATOR_MAX_CAP_UPDATED';
 
 export const updateRegulatorAction = ({ vdd, currentVDD, min, max }) => ({
     type: VOLTAGE_REGULATOR_UPDATED,
@@ -24,6 +31,11 @@ export const updateRegulatorAction = ({ vdd, currentVDD, min, max }) => ({
 export const moveVoltageRegulatorVddAction = vdd =>
     updateRegulatorAction({ vdd });
 
+export const updateVoltageRegulatorMaxCapAction = maxCap => ({
+    type: VOLTAGE_REGULATOR_MAX_CAP_UPDATED,
+    maxCap,
+});
+
 export default (state = initialState, action) => {
     switch (action.type) {
         case VOLTAGE_REGULATOR_UPDATED: {
@@ -32,6 +44,14 @@ export default (state = initialState, action) => {
                 currentVDD: action.currentVDD || state.currentVDD,
                 min: action.min || state.min,
                 max: action.max || state.max,
+                maxCap: state.maxCap || action.max,
+            };
+        }
+        case VOLTAGE_REGULATOR_MAX_CAP_UPDATED: {
+            setVoltageRegulatorMaxCap(action.maxCap);
+            return {
+                ...state,
+                ...action,
             };
         }
         default:

--- a/src/utils/persistentStore.js
+++ b/src/utils/persistentStore.js
@@ -61,3 +61,8 @@ export const getMaxBufferSize = defaultMaxBufferSize =>
     store().get('maxBufferSize', defaultMaxBufferSize);
 export const setMaxBufferSize = maxBufferSize =>
     store().set('maxBufferSize', maxBufferSize);
+
+export const getVoltageRegulatorMaxCap = defaultMaxCap =>
+    store().get('voltageRegulatorMaxCap', defaultMaxCap);
+export const setVoltageRegulatorMaxCap = maxCap =>
+    store().set('voltageRegulatorMaxCap', maxCap);


### PR DESCRIPTION
Allow user to limit max voltage supply
    
Customers may sometimes want to limit the max voltage supply that they
can set. This is to ensure that they don't select too high of a value
by mistake.

## Description
- By pressing **Ctrl + Alt + Shift + A** you may open the advanced settings menu in the sidebar.
- Under **Voltage Limit** you can limit the **Set supply voltage to: ** option at the top under **Source Meter**.

![image](https://user-images.githubusercontent.com/34618612/145417354-c7004c05-3be2-4619-90c7-3c702680ccb7.png)
