### PR TITLE
Never disable stop button

### DIFF
--- a/src/components/SidePanel/StartStop.jsx
+++ b/src/components/SidePanel/StartStop.jsx
@@ -92,7 +92,6 @@ export default () => {
                     title={startStopTitle}
                     className="w-100 secondary-btn start-stop active-animation"
                     variant="secondary"
-                    disabled={!rttRunning}
                     onClick={() => dispatch(samplingStop())}
                 >
                     <span className="mdi mdi-stop-circle" />


### PR DESCRIPTION
It should always be possible to stop the power profiler if it is running. This commits removes the possibility of having the stop button disabled.