### PR TITLE
fix: set default max voltage limit to 5V

### DIFF
--- a/src/reducers/voltageRegulatorReducer.js
+++ b/src/reducers/voltageRegulatorReducer.js
@@ -14,7 +14,7 @@ const initialState = {
     currentVDD: 3000,
     min: 1850,
     max: 3600,
-    maxCap: getVoltageRegulatorMaxCap(3600),
+    maxCap: getVoltageRegulatorMaxCap(5000),
 };
 
 const VOLTAGE_REGULATOR_UPDATED = 'VOLTAGE_REGULATOR_UPDATED';


### PR DESCRIPTION
If max voltage limit is set to 3.6V, then users who are not aware of the advanced setting will not be able to provide >3.6V from their power profiler kit.