### PR TITLE
Feat/save after device deselect

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@
 ### Changed
 
 - Added icons to Start/Stop buttons in `Real Time` pane.
+- Save / Export is now available after deselecting device
+  - Be aware that if you select device again the unsaved samples will be wiped
 
 ## 3.3.0 - 2021-12-15
 

--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -55,6 +55,7 @@ export default () => {
     if (!deviceOpen) {
         return (
             <SidePanel className="side-panel">
+                {options.index !== 0 && <Save />}
                 <Load />
                 <Instructions />
             </SidePanel>

--- a/src/components/SidePanel/SidePanel.jsx
+++ b/src/components/SidePanel/SidePanel.jsx
@@ -55,8 +55,8 @@ export default () => {
     if (!deviceOpen) {
         return (
             <SidePanel className="side-panel">
-                {options.index !== 0 && <Save />}
                 <Load />
+                {options.index !== 0 && <Save />}
                 <Instructions />
             </SidePanel>
         );

--- a/src/components/__tests__/SidePanel-test.jsx
+++ b/src/components/__tests__/SidePanel-test.jsx
@@ -16,12 +16,12 @@ describe('SidePanel', () => {
         expect(screen.getByText('Load')).toBeDefined();
     });
 
-    it('should not have LoadSave present at startup', () => {
+    it('should not have LoadSave present at if the number of samples is zero', () => {
         const screen = render(<SidePanel />);
         expect(screen.queryByText('Save / Export')).toBeNull();
     });
 
-    it('should have LoadSave present if options.index is not zero', () => {
+    it('should have LoadSave present if the number of samples is non-zero', () => {
         options.index = 1;
         const screen = render(<SidePanel />);
         expect(screen.getByText('Save / Export')).toBeDefined();

--- a/src/components/__tests__/SidePanel-test.jsx
+++ b/src/components/__tests__/SidePanel-test.jsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+
+import { options } from '../../globals';
+import { fireEvent, render } from '../../utils/testUtils';
+import SidePanel from '../SidePanel/SidePanel';
+
+describe('SidePanel', () => {
+    it('should have Load present at startup', () => {
+        const screen = render(<SidePanel />);
+        expect(screen.getByText('Load')).toBeDefined();
+    });
+
+    it('should not have LoadSave present at startup', () => {
+        const screen = render(<SidePanel />);
+        expect(screen.queryByText('Save / Export')).toBeNull();
+    });
+
+    it('should have LoadSave present if options.index is not zero', () => {
+        options.index = 1;
+        const screen = render(<SidePanel />);
+        expect(screen.getByText('Save / Export')).toBeDefined();
+    });
+
+    it('successfully opens SaveChoiceDialog when clicking Save / Export button', () => {
+        options.index = 1;
+        const screen = render(<SidePanel />);
+
+        const saveButton = screen.getByText('Save / Export');
+        fireEvent.click(saveButton);
+
+        expect(screen.getByText('What would you like to save?')).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Change

When the PPK is deselected and data has been collected the `Save / Export` button should still be visible. This is especially important since we remove the data when a new device is selected.
![image](https://user-images.githubusercontent.com/34618612/148380255-8e7a6f91-69ea-49ef-b92b-a7a7c847f8b4.png)

### Added Test Suite for Side Panel