### PR TITLE
Feat/cursor selection

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -192,7 +192,6 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
         (beginX, endX, beginY, endY) => {
             if (typeof beginX === 'undefined') {
                 chartReset(windowDuration);
-                resetCursor();
                 return;
             }
 
@@ -215,7 +214,6 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
             windowEndLock,
             chartReset,
             windowDuration,
-            resetCursor,
             chartWindow,
         ]
     );

--- a/src/components/Chart/ChartTop.jsx
+++ b/src/components/Chart/ChartTop.jsx
@@ -14,6 +14,7 @@ import { func, number, shape, string } from 'prop-types';
 
 import {
     chartState,
+    resetChart,
     resetCursorAndChart,
     toggleYAxisLock,
 } from '../../reducers/chartReducer';
@@ -101,7 +102,7 @@ const ChartTop = ({ chartPause, zoomToWindow, chartRef, windowDuration }) => {
                 <Toggle
                     label="LIVE VIEW"
                     onToggle={() =>
-                        live ? chartPause() : dispatch(resetCursorAndChart())
+                        live ? chartPause() : dispatch(resetChart())
                     }
                     isToggled={live}
                     variant="secondary"

--- a/src/components/Chart/ChartTop.jsx
+++ b/src/components/Chart/ChartTop.jsx
@@ -15,7 +15,6 @@ import { func, number, shape, string } from 'prop-types';
 import {
     chartState,
     resetChart,
-    resetCursorAndChart,
     toggleYAxisLock,
 } from '../../reducers/chartReducer';
 import { dataLoggerState } from '../../reducers/dataLoggerReducer';

--- a/src/components/Chart/StatBox.jsx
+++ b/src/components/Chart/StatBox.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { Unit, unit } from 'mathjs';
-import { instanceOf, node, number, string } from 'prop-types';
+import { arrayOf, instanceOf, node, number, string } from 'prop-types';
 
 import { formatDurationHTML } from '../../utils/duration';
 
@@ -41,12 +41,12 @@ const StatBox = ({
     max = null,
     delta = null,
     label,
-    action = null,
+    actionButtons = [],
 }) => (
     <div className="statbox d-flex flex-column mb-1">
         <div className="statbox-header">
             <h2 className="d-inline my-0">{label}</h2>
-            {action}
+            {actionButtons.length > 0 && actionButtons.map(button => button)}
         </div>
         <div className="d-flex flex-row flex-fill">
             {delta === null && (
@@ -76,7 +76,7 @@ StatBox.propTypes = {
     max: number,
     delta: number,
     label: string.isRequired,
-    action: node,
+    actionButtons: arrayOf(node),
 };
 
 export default StatBox;

--- a/src/reducers/chartReducer.js
+++ b/src/reducers/chartReducer.js
@@ -163,6 +163,10 @@ export const chartWindowLockAction = () => ({ type: CHART_WINDOW_LOCK });
 export const chartWindowUnLockAction = () => ({ type: CHART_WINDOW_UNLOCK });
 
 export const resetCursor = () => chartCursorAction(null, null);
+export const resetChart = () => (dispatch, getState) =>
+    dispatch(
+        chartWindowAction(null, null, getState().app.chart.windowDuration)
+    );
 export const resetCursorAndChart = () => (dispatch, getState) => {
     dispatch(
         chartWindowAction(null, null, getState().app.chart.windowDuration)


### PR DESCRIPTION
## New `Select All` option
![image](https://user-images.githubusercontent.com/34618612/152349405-215a52ea-be4f-47e5-865c-39d2d09e50c7.png)

### Comes with a hotkey option `alt+a`
Hotkey `alt+a` was selected instead of `ctrl+a` because of the electron
default behavior of `ctrl+a`. The reasoning is that it is cleaner to
select a different hotkey rather than removing default behavior.

## New hotkey, `esc`, to deselect cursor
The commit also implements hotkey `esc` to deselect current selection.

## The cursor is no longer deselected on returning to live view
Do not remove cursor (selection) on returning to live view (either by clicking the toggle `LIVE VIEW` or by pressing `middle wheel` or `right click`, reset the cursor only when using hotkey `esc` or on starting new sampling.

This change is enabled by an earlier commit (aa127621f024ee182dd42937827c56513de7e896) where the user may choose what to export. I believe the intention of resetting the cursor has been to not default into export the selection, but by allowing the user to explicitly state what is exported it is more convenient to leave the selection unless explicitly deselecting it.

