### PR TITLE
Emphasize that a given window duration is selected

### DIFF
--- a/src/components/Chart/ChartTop.jsx
+++ b/src/components/Chart/ChartTop.jsx
@@ -25,12 +25,14 @@ import './charttop.scss';
 
 const { gray700, nordicBlue } = colors;
 
-const TimeWindowButton = ({ label, zoomToWindow }) => {
+const TimeWindowButton = ({ label, zoomToWindow, currentWindowDuration }) => {
+    const toDuration = unit(label).to('us').toNumeric();
     return (
         <Button
             variant="secondary"
             size="sm"
-            onClick={() => zoomToWindow(unit(label).to('us').toNumeric())}
+            onClick={() => zoomToWindow(toDuration)}
+            active={currentWindowDuration === toDuration}
         >
             {label}
         </Button>
@@ -40,6 +42,7 @@ const TimeWindowButton = ({ label, zoomToWindow }) => {
 TimeWindowButton.propTypes = {
     label: string.isRequired,
     zoomToWindow: func.isRequired,
+    currentWindowDuration: number.isRequired,
 };
 
 const ChartTop = ({ chartPause, zoomToWindow, chartRef, windowDuration }) => {
@@ -93,6 +96,7 @@ const ChartTop = ({ chartPause, zoomToWindow, chartRef, windowDuration }) => {
                             label={label}
                             key={label}
                             zoomToWindow={zoomToWindow}
+                            currentWindowDuration={windowDuration}
                         />
                     ))}
                 </ButtonGroup>


### PR DESCRIPTION
Image below shows that the current window duration is 10s.

![image](https://user-images.githubusercontent.com/34618612/152376405-f7e8d0cd-0f51-4cb0-bbdd-92f9ad959c3d.png)

For example zooming out a bit will remove the focus from the button and leave all of them unfocused.