### PR TITLE
Do not reset index when sampling is complete

### DIFF
--- a/src/actions/deviceActions.js
+++ b/src/actions/deviceActions.js
@@ -272,7 +272,6 @@ export function open(deviceInfo) {
                 if (samplingRunning) {
                     dispatch(samplingStop());
                 }
-                options.index = 0;
             }
             if (triggerRunning || triggerSingleWaiting) {
                 dispatch(


### PR DESCRIPTION
Several new features depend on the options.index pointing at the
accurate place in the buffer. I see no reason for setting the index to
zero since we do not have a circular buffer.

At least note that the functions in globals.js; `timestampToIndex` and
`indexToTimestamp` rely on timestamp and index being somehow synchronized.