### PR TITLE
Feat/support larger files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## 3.4.2 - 2022-02-17
+
+### Fixed
+- Loading larger files are now supported.
+
 ## 3.4.1 - 2022-02-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ppk",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Power Profiler",
   "displayName": "Power Profiler",
   "repository": {

--- a/src/actions/fileActions.js
+++ b/src/actions/fileActions.js
@@ -56,7 +56,7 @@ export const save = () => async (_, getState) => {
     }
 };
 
-export const load = () => async dispatch => {
+export const load = setLoading => async dispatch => {
     const {
         filePaths: [filename],
     } =
@@ -67,10 +67,13 @@ export const load = () => async dispatch => {
         return;
     }
 
+    setLoading(true);
+    logger.info(`Restoring state from ${filename}`);
     updateTitle(filename);
     const result = await loadData(filename);
     if (!result) {
         logger.error(`Error loading from ${filename}`);
+        setLoading(false);
         return;
     }
     const { dataBuffer, bits, metadata } = result;
@@ -95,7 +98,8 @@ export const load = () => async dispatch => {
         dispatch(setTriggerState(triggerState));
     }
     if (currentPane !== null) dispatch(setCurrentPane(currentPane));
-    logger.info(`State restored from: ${filename}`);
+    logger.info(`State successfully restored`);
+    setLoading(false);
 };
 
 export const screenshot = () => async () => {

--- a/src/components/SidePanel/LoadSave.jsx
+++ b/src/components/SidePanel/LoadSave.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -17,11 +17,15 @@ import SaveChoiceDialog from '../SaveExport/SaveChoiceDialog';
 export const Load = () => {
     const dispatch = useDispatch();
 
+    const [loading, setLoading] = useState(false);
+
     return (
         <Button
-            className="w-100 secondary-btn"
+            title="Large files may take a while to process"
+            className={`w-100 secondary-btn ${loading && 'active-anim'}`}
             variant="set"
-            onClick={() => dispatch(load())}
+            onClick={() => dispatch(load(setLoading))}
+            disabled={loading}
         >
             Load
         </Button>


### PR DESCRIPTION
This PR introduces:
- A way to find the exact buffer size requirement for loading the decompressed data of a .ppk file.
- A loading animation during loading of .ppk files.

In the future we should consider a flow which allows us to easier
determine the size requirement without decompressing the whole file
first.