### PR TITLE
Handle architecture specific buffer size limit

### DIFF
--- a/src/components/SidePanel/BufferSettings.jsx
+++ b/src/components/SidePanel/BufferSettings.jsx
@@ -8,6 +8,8 @@ import React from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
+import { kMaxLength as maxBufferSizeForSystem } from 'buffer';
+import { unit } from 'mathjs';
 import {
     CollapsibleGroup,
     NumberInlineInput,
@@ -25,9 +27,12 @@ const { getCurrentWindow } = require('electron').remote;
 export const BufferSettings = () => {
     const maxBufferSize = useSelector(maxBufferSizeSelector);
     const dispatch = useDispatch();
-    const range = { min: 1, max: Infinity };
+    const range = {
+        min: 1,
+        max: unit(maxBufferSizeForSystem, 'bytes').toNumber('MB'),
+    };
     const [changed, setChanged] = React.useState(false);
-
+    console.log(range.max);
     return (
         <CollapsibleGroup
             heading="Sampling Buffer Size"

--- a/src/components/SidePanel/BufferSettings.jsx
+++ b/src/components/SidePanel/BufferSettings.jsx
@@ -32,7 +32,6 @@ export const BufferSettings = () => {
         max: unit(maxBufferSizeForSystem, 'bytes').toNumber('MB'),
     };
     const [changed, setChanged] = React.useState(false);
-    console.log(range.max);
     return (
         <CollapsibleGroup
             heading="Sampling Buffer Size"

--- a/src/utils/persistentStore.js
+++ b/src/utils/persistentStore.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { kMaxLength as maxBufferSizeForSystem } from 'buffer';
+import { unit } from 'mathjs';
 import {
     getAppDataDir,
     getPersistentStore as store,
@@ -57,8 +59,12 @@ export const getDuration = (maxSampleFreq, defaultValue) =>
 export const setDuration = (maxSampleFreq, durationSeconds) =>
     store().set(`durationSeconds-${maxSampleFreq}`, durationSeconds);
 
-export const getMaxBufferSize = defaultMaxBufferSize =>
-    store().get('maxBufferSize', defaultMaxBufferSize);
+export const getMaxBufferSize = defaultMaxBufferSize => {
+    const storedValue = store().get('maxBufferSize', defaultMaxBufferSize);
+    return storedValue > unit(maxBufferSizeForSystem, 'bytes').toNumber('MB')
+        ? defaultMaxBufferSize
+        : storedValue;
+};
 export const setMaxBufferSize = maxBufferSize =>
     store().set('maxBufferSize', maxBufferSize);
 


### PR DESCRIPTION
## Issue reported by customer
Not able to load file on windows machine using the 32-bit application. After inspecting the file it showed to be >1GB  decompressed, which according to the node documentation is above the max size for buffers on 32-bit systems. The same limit is 4GB for 64-bit systems. Hence, this PR handles the system specific limits and gives out a more verbose error for the customer to see.

This PR also implements a restriction on sample size to restrict customers to save bigger samples than they would be able to open again.