### PR TITLE
Fix/toggle off colors

### DIFF
--- a/src/components/Chart/ChartTop.jsx
+++ b/src/components/Chart/ChartTop.jsx
@@ -9,7 +9,7 @@ import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import { useDispatch, useSelector } from 'react-redux';
 import { unit } from 'mathjs';
-import { colors, Toggle } from 'pc-nrfconnect-shared';
+import { Toggle } from 'pc-nrfconnect-shared';
 import { func, number, shape, string } from 'prop-types';
 
 import {
@@ -23,19 +23,15 @@ import ChartOptions from './ChartOptions';
 
 import './charttop.scss';
 
-const { gray700, nordicBlue } = colors;
-
-const TimeWindowButton = ({ label, zoomToWindow }) => {
-    return (
-        <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => zoomToWindow(unit(label).to('us').toNumeric())}
-        >
-            {label}
-        </Button>
-    );
-};
+const TimeWindowButton = ({ label, zoomToWindow }) => (
+    <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => zoomToWindow(unit(label).to('us').toNumeric())}
+    >
+        {label}
+    </Button>
+);
 
 TimeWindowButton.propTypes = {
     label: string.isRequired,
@@ -81,8 +77,6 @@ const ChartTop = ({ chartPause, zoomToWindow, chartRef, windowDuration }) => {
                     isToggled={yAxisLock}
                     variant="secondary"
                     labelRight
-                    barColor={gray700}
-                    barColorToggled={nordicBlue}
                 />
                 {yAxisLock && <ChartOptions chartRef={chartRef} />}
             </div>
@@ -104,9 +98,7 @@ const ChartTop = ({ chartPause, zoomToWindow, chartRef, windowDuration }) => {
                         live ? chartPause() : dispatch(resetChart())
                     }
                     isToggled={live}
-                    variant="secondary"
-                    barColor={gray700}
-                    barColorToggled={nordicBlue}
+                    variant="primary"
                 />
             )}
         </div>

--- a/src/components/Chart/ChartTop.jsx
+++ b/src/components/Chart/ChartTop.jsx
@@ -75,7 +75,7 @@ const ChartTop = ({ chartPause, zoomToWindow, chartRef, windowDuration }) => {
                         }
                     }}
                     isToggled={yAxisLock}
-                    variant="secondary"
+                    variant="primary"
                     labelRight
                 />
                 {yAxisLock && <ChartOptions chartRef={chartRef} />}

--- a/src/components/SidePanel/DisplayOptions.jsx
+++ b/src/components/SidePanel/DisplayOptions.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { CollapsibleGroup, colors, Toggle } from 'pc-nrfconnect-shared';
+import { CollapsibleGroup, Toggle } from 'pc-nrfconnect-shared';
 
 import {
     chartState,
@@ -15,8 +15,6 @@ import {
 } from '../../reducers/chartReducer';
 import { isDataLoggerPane } from '../../utils/panes';
 import DigitalChannels from './DigitalChannels';
-
-const { gray700, nordicBlue } = colors;
 
 export default () => {
     const dispatch = useDispatch();
@@ -30,9 +28,7 @@ export default () => {
                 onToggle={() => dispatch(toggleTimestamps())}
                 isToggled={timestampsVisible}
                 label="Timestamps"
-                variant="secondary"
-                barColor={gray700}
-                barColorToggled={nordicBlue}
+                variant="primary"
             />
             {hasDigitalChannels && isDataLogger && (
                 <>
@@ -40,9 +36,7 @@ export default () => {
                         onToggle={() => dispatch(toggleDigitalChannels())}
                         isToggled={digitalChannelsVisible}
                         label="Digital channels"
-                        variant="secondary"
-                        barColor={gray700}
-                        barColorToggled={nordicBlue}
+                        variant="primary"
                     />
                     <DigitalChannels />
                 </>

--- a/src/components/SidePanel/PowerMode.jsx
+++ b/src/components/SidePanel/PowerMode.jsx
@@ -62,9 +62,7 @@ export default () => {
                     onToggle={() => dispatch(setDeviceRunning(!deviceRunning))}
                     isToggled={deviceRunning}
                     label="Enable power output"
-                    barColor={gray700}
-                    barColorToggled={nordicBlue}
-                    variant="secondary"
+                    variant="primary"
                 />
             )}
         </Group>

--- a/src/components/SidePanel/SwitchPoints.jsx
+++ b/src/components/SidePanel/SwitchPoints.jsx
@@ -96,7 +96,7 @@ const SwitchPoints = () => {
                     onToggle={() => dispatch(spikeFilteringToggle())}
                     isToggled={spikeFiltering}
                     label="Spike filtering"
-                    variant="secondary"
+                    variant="primary"
                 />
             )}
         </CollapsibleGroup>


### PR DESCRIPTION
This commit resolves an issue with the off-state of toggle buttons being single-color, meaning that the buttons should now have distinct colors inside the toggle to see the toggle effect.

### Before
![image](https://user-images.githubusercontent.com/34618612/171626351-8fa7e6f3-6b61-4621-a727-d63ad142b48c.png)

### After
![image](https://user-images.githubusercontent.com/34618612/171626390-c4fc5ab2-7073-4d09-a42b-b2e1967f927d.png)
