### PR TITLE
Report what ppk is selected when sample is started

### DIFF
--- a/src/actions/deviceActions.ts
+++ b/src/actions/deviceActions.ts
@@ -124,6 +124,11 @@ export function samplingStart() {
                 ? EventAction.START_REAL_TIME_SAMPLE
                 : EventAction.START_DATA_LOGGER_SAMPLE
         );
+        usageData.sendUsageData(
+            device!.capabilities.hwTrigger
+                ? EventAction.SAMPLE_STARTED_WITH_PPK1_SELECTED
+                : EventAction.SAMPLE_STARTED_WITH_PPK2_SELECTED
+        );
         options.data.fill(NaN);
         if (options.bits) {
             options.bits.fill(0);

--- a/src/usageDataActions.ts
+++ b/src/usageDataActions.ts
@@ -13,6 +13,8 @@ const EventAction = {
     Y_MAX_SET_EXPLICITLY: 'YMax was explicitly changed',
     START_DATA_LOGGER_SAMPLE: 'Data Logger sampling started',
     START_REAL_TIME_SAMPLE: 'Real Time sampling started',
+    SAMPLE_STARTED_WITH_PPK1_SELECTED: 'Sample started with PPK1 selected',
+    SAMPLE_STARTED_WITH_PPK2_SELECTED: 'Sample started with PPK2 selected',
 };
 
 export default EventAction;


### PR DESCRIPTION
To improve usage statistics we would like to know what device is selected when a sample is started, because the a simple device selection will be triggered even when wrong devices are selected.