### PR TITLE
Remove device filter in order to display PPK2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## 3.5.2 - 2022-10-12
+
+### Fixed
+
+-   PPK2 did not show up in **Device Selector** when the appropriate firmware
+    was not flashed. This release removes the filtering that was introduced in
+    v3.5.0.
+
 ## 3.5.1 - 2022-10-5
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-ppk",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "description": "Power Profiler",
     "displayName": "Power Profiler",
     "repository": {

--- a/src/components/DeviceSelector.jsx
+++ b/src/components/DeviceSelector.jsx
@@ -37,19 +37,6 @@ const mapState = () => ({
     deviceSetup,
 });
 
-const deviceFilter = device => {
-    const PPK2 = 'power_profiler_kit_2 1.0.0-5e7cc60';
-    const supportedPPK1Devices = [
-        'NRF51_FAMILY',
-        'NRF52_FAMILY',
-        'NRF53_FAMILY',
-    ];
-    return (
-        device.dfuTriggerVersion?.semVer === PPK2 ||
-        supportedPPK1Devices.includes(device.jlink?.deviceFamily)
-    );
-};
-
 const mapDispatch = dispatch => ({
     onDeviceSelected: device => {
         logger.info(
@@ -65,7 +52,6 @@ const mapDispatch = dispatch => ({
         logger.info(`Opening device with s/n ${device.serialNumber}`);
         dispatch(open(device));
     },
-    deviceFilter,
 });
 
 export default connect(mapState, mapDispatch)(DeviceSelector);


### PR DESCRIPTION
PPK2 did not show up in device filter when the firmware was not exactly the correct one. The firmware may vary, for example if the device is just from factory, or if customer has flashed a custom fw.

We want to allow customers to be able to select any device, and then we'll flash the correct firmware when the device is selected.