### PR TITLE
Add 20s time range to the chart view.

### DIFF
--- a/src/components/Chart/ChartTop.jsx
+++ b/src/components/Chart/ChartTop.jsx
@@ -51,6 +51,7 @@ const ChartTop = ({ chartPause, zoomToWindow, chartRef, windowDuration }) => {
         '1s',
         '3s',
         '10s',
+        '20s',
         '1min',
         '10min',
         '1h',


### PR DESCRIPTION
Using LTE-M with 10s RRC Activity Timer benefits from this range between 10s and 1min. That doesn't provide the general function to zoom the selected scope, but it's a quite simple change which helps also much.