### PR TITLE
Typescript conversion Mars 2023

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@
     -   Hotkey: `alt+z`
 -   Option to toggle logarithmic scale on the Y-Axis, by @danielkucera.
 
+## Fixed
+
+-   PPK1: Could select higher VDD then what the device supports.
+
 ## 3.5.4 - 2023-02-12
 
 ### Added

--- a/src/actions/deviceActions.ts
+++ b/src/actions/deviceActions.ts
@@ -64,8 +64,8 @@ import {
     triggerWindowRangeAction,
 } from '../slices/triggerSlice';
 import {
-    resetVoltageMaxCapForPPK1,
-    updateRegulatorAction,
+    updateMaxCapOnDeviceSelected,
+    updateRegulator as updateRegulatorAction,
 } from '../slices/voltageRegulatorSlice';
 import EventAction from '../usageDataActions';
 import { convertBits16 } from '../utils/bitConversion';
@@ -321,15 +321,7 @@ export function open(deviceInfo: any) {
 
         try {
             device = Device(deviceInfo, onSample);
-
-            if (
-                device.capabilities.hwTrigger &&
-                getState().app.voltageRegulator.maxCap > 3600
-            ) {
-                // PPK1 PPK_1_SELECTED
-                resetMaxVoltageForPPK1(dispatch);
-            }
-
+            console.log(device);
             usageData.sendUsageData(
                 device.capabilities.hwTrigger
                     ? EventAction.PPK_1_SELECTED
@@ -367,6 +359,11 @@ export function open(deviceInfo: any) {
                     ...device.vddRange,
                 })
             );
+            dispatch(
+                updateMaxCapOnDeviceSelected({
+                    isRTTDevice: isRTTDevice(device),
+                })
+            );
             await dispatch(initGains());
             if (device.capabilities.ppkSetSpikeFilter) {
                 dispatch(updateSpikeFilter());
@@ -393,6 +390,7 @@ export function open(deviceInfo: any) {
             dispatch({ type: 'device/deselectDevice' });
         }
 
+        console.log(device);
         dispatch(
             deviceOpenedAction({
                 portName: deviceInfo.serialNumber,
@@ -620,7 +618,4 @@ export function updateTriggerLevel(triggerLevel: number) {
     };
 }
 
-const resetMaxVoltageForPPK1 = (dispatch: TDispatch) => {
-    dispatch(resetVoltageMaxCapForPPK1());
-    usageData.sendUsageData(EventAction.VOLTAGE_MAX_LIMIT_RESET);
-};
+export const isConnectedToPPK1Device = () => isRTTDevice(device);

--- a/src/actions/deviceActions.ts
+++ b/src/actions/deviceActions.ts
@@ -11,12 +11,8 @@
 import { isDevelopment, logger, usageData } from 'pc-nrfconnect-shared';
 
 import Device from '../device';
-import {
-    isRTTDevice,
-    isSerialDevice,
-    SampleValues,
-    SupportedDevice,
-} from '../device/types';
+import { SampleValues, SupportedDevice } from '../device/types';
+import { isRTTDevice, isSerialDevice } from '../device/utils';
 import {
     indexToTimestamp,
     initializeBitsBuffer,
@@ -321,7 +317,6 @@ export function open(deviceInfo: any) {
 
         try {
             device = Device(deviceInfo, onSample);
-            console.log(device);
             usageData.sendUsageData(
                 device.capabilities.hwTrigger
                     ? EventAction.PPK_1_SELECTED
@@ -390,7 +385,6 @@ export function open(deviceInfo: any) {
             dispatch({ type: 'device/deselectDevice' });
         }
 
-        console.log(device);
         dispatch(
             deviceOpenedAction({
                 portName: deviceInfo.serialNumber,

--- a/src/components/Chart/ChartTop.tsx
+++ b/src/components/Chart/ChartTop.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../slices/chartSlice';
 import { dataLoggerState } from '../../slices/dataLoggerSlice';
 import { isDataLoggerPane as isDataLoggerPaneSelector } from '../../utils/panes';
+// @ts-expect-error Is currently a jsx file
 import ChartOptions from './ChartOptions';
 
 import './charttop.scss';
@@ -52,7 +53,8 @@ const ChartTop = ({
     windowDuration,
 }: ChartTop) => {
     const dispatch = useDispatch();
-    const { windowBegin, windowEnd, yAxisLock, yAxisLog } = useSelector(chartState);
+    const { windowBegin, windowEnd, yAxisLock, yAxisLog } =
+        useSelector(chartState);
     const { maxFreqLog10, sampleFreqLog10 } = useSelector(dataLoggerState);
     const isDataLoggerPane = useSelector(isDataLoggerPaneSelector);
     const live = windowBegin === 0 && windowEnd === 0;

--- a/src/components/DeviceSelector.ts
+++ b/src/components/DeviceSelector.ts
@@ -5,9 +5,16 @@
  */
 
 import { connect } from 'react-redux';
-import { DeviceSelector, getAppFile, logger } from 'pc-nrfconnect-shared';
+import {
+    Device,
+    DeviceSelector,
+    DeviceSelectorProps,
+    getAppFile,
+    logger,
+} from 'pc-nrfconnect-shared';
 
 import { close, open } from '../actions/deviceActions';
+import { TDispatch } from '../slices/thunk';
 
 const deviceListing = {
     nordicUsb: true,
@@ -37,8 +44,8 @@ const mapState = () => ({
     deviceSetup,
 });
 
-const mapDispatch = dispatch => ({
-    onDeviceSelected: device => {
+const mapDispatch = (dispatch: TDispatch): Partial<DeviceSelectorProps> => ({
+    onDeviceSelected: (device: Device) => {
         logger.info(
             `Validating firmware for device with s/n ${device.serialNumber}`
         );

--- a/src/components/SidePanel/BufferSettings.tsx
+++ b/src/components/SidePanel/BufferSettings.tsx
@@ -54,7 +54,8 @@ export const BufferSettings = () => {
             </FormLabel>
             {newValue !== maxBufferSize ? (
                 <Button
-                    className="w-100 mt-2 secondary-btn"
+                    className="w-100"
+                    variant="secondary"
                     onClick={() => {
                         usageData.sendUsageData(
                             EventAction.BUFFER_SIZE_CHANGED,

--- a/src/components/SidePanel/BufferSettings.tsx
+++ b/src/components/SidePanel/BufferSettings.tsx
@@ -31,7 +31,7 @@ export const BufferSettings = () => {
         max: unit(maxBufferSizeForSystem, 'bytes').toNumber('MB'),
     };
 
-    const [newValue, setNewValue] = useState(maxBufferSize);
+    const [bufferSize, setBufferSize] = useState(maxBufferSize);
 
     return (
         <Group
@@ -44,26 +44,26 @@ export const BufferSettings = () => {
             >
                 <span className="flex-fill">Max size of buffer</span>
                 <NumberInlineInput
-                    value={newValue}
+                    value={bufferSize}
                     range={range}
                     onChange={value => {
-                        setNewValue(value);
+                        setBufferSize(value);
                     }}
                 />
                 <span>&nbsp;MB</span>
             </FormLabel>
-            {newValue !== maxBufferSize ? (
+            {bufferSize !== maxBufferSize ? (
                 <Button
                     className="w-100"
                     variant="secondary"
                     onClick={() => {
                         usageData.sendUsageData(
                             EventAction.BUFFER_SIZE_CHANGED,
-                            `${newValue}`
+                            `${bufferSize}`
                         );
                         dispatch(
                             changeMaxBufferSizeAction({
-                                maxBufferSize: newValue,
+                                maxBufferSize: bufferSize,
                             })
                         );
                         getCurrentWindow().reload();

--- a/src/components/SidePanel/BufferSettings.tsx
+++ b/src/components/SidePanel/BufferSettings.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
+import { getCurrentWindow } from '@electron/remote';
 import { kMaxLength as maxBufferSizeForSystem } from 'buffer';
 import { unit } from 'mathjs';
 import {
@@ -21,8 +22,6 @@ import {
     maxBufferSize as maxBufferSizeSelector,
 } from '../../slices/dataLoggerSlice';
 import EventAction from '../../usageDataActions';
-
-const { getCurrentWindow } = require('@electron/remote');
 
 export const BufferSettings = () => {
     const maxBufferSize = useSelector(maxBufferSizeSelector);
@@ -54,7 +53,7 @@ export const BufferSettings = () => {
                         );
                         usageData.sendUsageData(
                             EventAction.BUFFER_SIZE_CHANGED,
-                            newValue
+                            `${newValue}`
                         );
                         setChanged(true);
                     }}

--- a/src/components/SidePanel/CapVoltageSettings.tsx
+++ b/src/components/SidePanel/CapVoltageSettings.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Form from 'react-bootstrap/Form';
+import FormLabel from 'react-bootstrap/FormLabel';
 import { useDispatch, useSelector } from 'react-redux';
 import {
     CollapsibleGroup,
@@ -35,7 +35,7 @@ export const CapVoltageSettings = () => {
                 className="voltage-regulator"
                 title="Supply voltage to the device will be capped to this value"
             >
-                <Form.Label htmlFor="cap-slider-vdd">
+                <FormLabel htmlFor="cap-slider-vdd">
                     <span className="flex-fill">Set max supply voltage to</span>
                     <NumberInlineInput
                         value={maxCap}
@@ -53,12 +53,12 @@ export const CapVoltageSettings = () => {
                             );
                             usageData.sendUsageData(
                                 EventAction.VOLTAGE_MAX_LIMIT_CHANGED,
-                                maxCap
+                                `${maxCap}`
                             );
                         }}
                     />
                     &nbsp;mV
-                </Form.Label>
+                </FormLabel>
                 <Slider
                     id="cap-slider-vdd"
                     values={[maxCap]}
@@ -77,7 +77,7 @@ export const CapVoltageSettings = () => {
                         );
                         usageData.sendUsageData(
                             EventAction.VOLTAGE_MAX_LIMIT_CHANGED,
-                            maxCap
+                            `${maxCap}`
                         );
                     }}
                 />

--- a/src/components/SidePanel/CapVoltageSettings.tsx
+++ b/src/components/SidePanel/CapVoltageSettings.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import FormLabel from 'react-bootstrap/FormLabel';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -15,14 +15,34 @@ import {
 } from 'pc-nrfconnect-shared';
 
 import {
-    updateVoltageRegulatorMaxCapAction,
+    isConnectedToPPK1Device,
+    updateRegulator,
+} from '../../actions/deviceActions';
+import {
+    moveVoltageRegulatorVdd,
+    updateVoltageRegulatorMaxCapPPK1,
+    updateVoltageRegulatorMaxCapPPK2,
     voltageRegulatorState,
 } from '../../slices/voltageRegulatorSlice';
 import EventAction from '../../usageDataActions';
 
 export const CapVoltageSettings = () => {
-    const { min, max, maxCap } = useSelector(voltageRegulatorState);
+    const { min, max, vdd, maxCap } = useSelector(voltageRegulatorState);
+    const [newMaxCap, setNewMaxCap] = useState(maxCap);
     const dispatch = useDispatch();
+
+    const updateMaxCap = () =>
+        isConnectedToPPK1Device()
+            ? dispatch(updateVoltageRegulatorMaxCapPPK1(newMaxCap))
+            : dispatch(updateVoltageRegulatorMaxCapPPK2(newMaxCap));
+
+    const updateVoltageRegulator = () => {
+        updateMaxCap();
+        if (newMaxCap < vdd) {
+            dispatch(moveVoltageRegulatorVdd(newMaxCap));
+            dispatch(updateRegulator());
+        }
+    };
 
     return (
         <CollapsibleGroup
@@ -38,22 +58,14 @@ export const CapVoltageSettings = () => {
                 <FormLabel htmlFor="cap-slider-vdd">
                     <span className="flex-fill">Set max supply voltage to</span>
                     <NumberInlineInput
-                        value={maxCap}
+                        value={newMaxCap}
                         range={{ min, max }}
-                        onChange={value =>
-                            dispatch(
-                                updateVoltageRegulatorMaxCapAction({
-                                    maxCap: value,
-                                })
-                            )
-                        }
+                        onChange={value => setNewMaxCap(value)}
                         onChangeComplete={() => {
-                            dispatch(
-                                updateVoltageRegulatorMaxCapAction({ maxCap })
-                            );
+                            updateVoltageRegulator();
                             usageData.sendUsageData(
                                 EventAction.VOLTAGE_MAX_LIMIT_CHANGED,
-                                `${maxCap}`
+                                `${newMaxCap}`
                             );
                         }}
                     />
@@ -61,23 +73,14 @@ export const CapVoltageSettings = () => {
                 </FormLabel>
                 <Slider
                     id="cap-slider-vdd"
-                    values={[maxCap]}
+                    values={[newMaxCap]}
                     range={{ min, max }}
-                    onChange={[
-                        value =>
-                            dispatch(
-                                updateVoltageRegulatorMaxCapAction({
-                                    maxCap: value,
-                                })
-                            ),
-                    ]}
+                    onChange={[value => setNewMaxCap(value)]}
                     onChangeComplete={() => {
-                        dispatch(
-                            updateVoltageRegulatorMaxCapAction({ maxCap })
-                        );
+                        updateVoltageRegulator();
                         usageData.sendUsageData(
                             EventAction.VOLTAGE_MAX_LIMIT_CHANGED,
-                            `${maxCap}`
+                            `${newMaxCap}`
                         );
                     }}
                 />

--- a/src/components/SidePanel/SpikeFilter.jsx
+++ b/src/components/SidePanel/SpikeFilter.jsx
@@ -5,10 +5,9 @@
  */
 
 import React from 'react';
-import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
-import { CollapsibleGroup, Slider } from 'pc-nrfconnect-shared';
+import { Button, CollapsibleGroup, Slider } from 'pc-nrfconnect-shared';
 
 import { updateSpikeFilter } from '../../actions/deviceActions';
 import { appState } from '../../slices/appSlice';

--- a/src/components/SidePanel/VoltageRegulator.tsx
+++ b/src/components/SidePanel/VoltageRegulator.tsx
@@ -13,7 +13,7 @@ import { NumberInlineInput, Slider } from 'pc-nrfconnect-shared';
 import { updateRegulator } from '../../actions/deviceActions';
 import { appState } from '../../slices/appSlice';
 import {
-    moveVoltageRegulatorVddAction,
+    moveVoltageRegulatorVdd,
     voltageRegulatorState,
 } from '../../slices/voltageRegulatorSlice';
 
@@ -29,7 +29,7 @@ const VoltageRegulator = () => {
 
     useEffect(() => {
         if (vdd > max) {
-            dispatch(moveVoltageRegulatorVddAction({ vdd: max }));
+            dispatch(moveVoltageRegulatorVdd(max));
         }
     }, [vdd, max, dispatch]);
 
@@ -42,11 +42,9 @@ const VoltageRegulator = () => {
                         value={vdd}
                         range={{ min, max }}
                         onChange={value =>
-                            dispatch(
-                                moveVoltageRegulatorVddAction({ vdd: value })
-                            )
+                            dispatch(moveVoltageRegulatorVdd(value))
                         }
-                        onChangeComplete={() => dispatch(updateRegulator(vdd))}
+                        onChangeComplete={() => dispatch(updateRegulator())}
                     />{' '}
                     mV
                 </Form.Label>
@@ -55,12 +53,9 @@ const VoltageRegulator = () => {
                     values={[vdd]}
                     range={{ min, max }}
                     onChange={[
-                        value =>
-                            dispatch(
-                                moveVoltageRegulatorVddAction({ vdd: value })
-                            ),
+                        value => dispatch(moveVoltageRegulatorVdd(value)),
                     ]}
-                    onChangeComplete={() => dispatch(updateRegulator(vdd))}
+                    onChangeComplete={() => dispatch(updateRegulator())}
                 />
             </div>
         </BootstrapCollapse>

--- a/src/components/SidePanel/sidepanel.scss
+++ b/src/components/SidePanel/sidepanel.scss
@@ -117,10 +117,6 @@
         padding-bottom: 0;
     }
 
-    .restart-app-btn {
-        margin-top: 8px;
-    }
-
     .start-stop {
         display: flex;
         align-items: center;

--- a/src/components/__tests__/ExportDialog-test.jsx
+++ b/src/components/__tests__/ExportDialog-test.jsx
@@ -15,7 +15,8 @@ import ExportDialog from '../SaveExport/ExportDialog';
 jest.mock('../../utils/persistentStore', () => ({
     getLastSaveDir: () => 'mocked/save/dir',
     getMaxBufferSize: () => 200,
-    getVoltageRegulatorMaxCap: () => 5000,
+    getVoltageRegulatorMaxCapPPK1: () => 3600,
+    getVoltageRegulatorMaxCapPPK2: () => 5000,
     getDigitalChannels: () => [
         true,
         true,

--- a/src/device/index.ts
+++ b/src/device/index.ts
@@ -18,7 +18,7 @@ export default (
     device: any,
     onSampleCallback: (values: SampleValues) => void
 ) => {
-    const instance = device.traits.jlink // isRTTDevice(device)
+    const instance = device.traits.jlink
         ? new RTTDevice(device, onSampleCallback)
         : new SerialDevice(device, onSampleCallback);
 

--- a/src/device/rttDevice.ts
+++ b/src/device/rttDevice.ts
@@ -13,7 +13,7 @@ import { getDeviceLibContext, logger } from 'pc-nrfconnect-shared';
 
 import PPKCmd from '../constants';
 import Device, { convertFloatToByteBuffer } from './abstractDevice';
-import { SampleValues } from './types';
+import type { SampleValues } from './types';
 
 export const SAMPLES_PER_AVERAGE = 10;
 const deviceLibContext = getDeviceLibContext();
@@ -130,7 +130,6 @@ class RTTDevice extends Device {
     private byteHandlerFn: (byte: number) => void;
 
     public timestamp: number;
-    public isRTTDevice = true;
 
     constructor(
         device: any,

--- a/src/device/rttDevice.ts
+++ b/src/device/rttDevice.ts
@@ -109,6 +109,8 @@ class RTTDevice extends Device {
 
     resistors = { hi: 1.8, mid: 28.0, lo: 510.0 };
 
+    vdd = 3000;
+
     vddRange = { min: 1850, max: 3600 };
 
     readloopRunning = false;
@@ -128,6 +130,7 @@ class RTTDevice extends Device {
     private byteHandlerFn: (byte: number) => void;
 
     public timestamp: number;
+    public isRTTDevice = true;
 
     constructor(
         device: any,

--- a/src/device/serialDevice.ts
+++ b/src/device/serialDevice.ts
@@ -52,6 +52,7 @@ class SerialDevice extends Device {
 
     public adcSamplingTimeUs = 10;
     public resistors = { hi: 1.8, mid: 28, lo: 500 };
+    public vdd = 5000;
     public vddRange = { min: 800, max: 5000 };
     public triggerWindowRange = { min: 1, max: 100 };
     public isRunningInitially = false;

--- a/src/device/types.ts
+++ b/src/device/types.ts
@@ -18,7 +18,7 @@ export interface SampleValues {
 // Should test the capabilities from either deviceInfo or a device instance to
 // see if device is instance of RTTDevice
 export function isRTTDevice(deviceToTest: any): deviceToTest is RTTDevice {
-    return deviceToTest.capabilities.jlink;
+    return deviceToTest?.isRTTDevice;
 }
 
 export function isSerialDevice(

--- a/src/device/types.ts
+++ b/src/device/types.ts
@@ -15,18 +15,6 @@ export interface SampleValues {
     endOfTrigger?: boolean;
 }
 
-// Should test the capabilities from either deviceInfo or a device instance to
-// see if device is instance of RTTDevice
-export function isRTTDevice(deviceToTest: any): deviceToTest is RTTDevice {
-    return deviceToTest?.isRTTDevice;
-}
-
-export function isSerialDevice(
-    deviceToTest: any
-): deviceToTest is SerialDevice {
-    return !isRTTDevice(deviceToTest);
-}
-
 export type SupportedDevice = RTTDevice | SerialDevice;
 
 export interface serialport {

--- a/src/device/utils.ts
+++ b/src/device/utils.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+import RTTDevice from './rttDevice';
+import SerialDevice from './serialDevice';
+
+export function isRTTDevice(
+    device: null | RTTDevice | SerialDevice
+): device is RTTDevice {
+    return device != null && device instanceof RTTDevice;
+}
+
+export function isSerialDevice(
+    device: null | RTTDevice | SerialDevice
+): device is SerialDevice {
+    return device != null && !isRTTDevice(device);
+}

--- a/src/slices/voltageRegulatorSlice.ts
+++ b/src/slices/voltageRegulatorSlice.ts
@@ -3,13 +3,14 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
-/* eslint-disable @typescript-eslint/no-non-null-assertion -- TODO: Remove, only added for conservative refactoring to typescript */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import {
-    getVoltageRegulatorMaxCap,
-    setVoltageRegulatorMaxCap,
+    getVoltageRegulatorMaxCapPPK1,
+    getVoltageRegulatorMaxCapPPK2,
+    setVoltageRegulatorMaxCapPPK1 as persistVoltageRegulatorMaxCapPPK1,
+    setVoltageRegulatorMaxCapPPK2 as persistVoltageRegulatorMaxCapPPK2,
 } from '../utils/persistentStore';
 import type { RootState } from '.';
 
@@ -19,6 +20,8 @@ interface VoltageRegulatorState {
     min: number;
     max: number;
     maxCap: number;
+    maxCapPPK1: number;
+    maxCapPPK2: number;
 }
 
 const initialState = (): VoltageRegulatorState => ({
@@ -26,47 +29,63 @@ const initialState = (): VoltageRegulatorState => ({
     currentVDD: 3000,
     min: 1850,
     max: 3600,
-    maxCap: getVoltageRegulatorMaxCap(5000),
+    maxCap: 3600,
+    maxCapPPK1: getVoltageRegulatorMaxCapPPK1(3600),
+    maxCapPPK2: getVoltageRegulatorMaxCapPPK2(5000),
 });
 
 const voltageRegulatorSlice = createSlice({
     name: 'voltageRegulator',
     initialState: initialState(),
     reducers: {
-        updateRegulatorAction(
+        updateRegulator(
             state,
-            action: PayloadAction<{
+            {
+                payload: { vdd, currentVDD, min, max },
+            }: PayloadAction<{
                 vdd?: number;
                 currentVDD?: number;
                 min?: number;
                 max?: number;
             }>
         ) {
-            return {
-                vdd: action.payload.vdd || state.vdd,
-                currentVDD: action.payload.currentVDD || state.currentVDD,
-                min: action.payload.min || state.min,
-                max: action.payload.max || state.max,
-                maxCap: state.maxCap || action.payload.max!,
-            };
+            state.vdd = vdd || state.vdd;
+            state.currentVDD = currentVDD || state.currentVDD;
+            state.min = min || state.min;
+            state.max = max || state.max;
+            // state.maxCap = state.maxCapPPK2 || max!;
         },
-        moveVoltageRegulatorVddAction(
+        updateMaxCapOnDeviceSelected(
             state,
-            action: PayloadAction<{ vdd: number }>
+            {
+                payload: { isRTTDevice },
+            }: PayloadAction<{ isRTTDevice: boolean }>
         ) {
-            const { vdd } = action.payload;
-            return { ...state, vdd };
+            state.maxCap =
+                isRTTDevice === true ? state.maxCapPPK1 : state.maxCapPPK2;
         },
-        updateVoltageRegulatorMaxCapAction(
+        moveVoltageRegulatorVdd(
             state,
-            action: PayloadAction<{ maxCap: number }>
+            { payload: vdd }: PayloadAction<number>
         ) {
-            const { maxCap } = action.payload;
-            setVoltageRegulatorMaxCap(maxCap);
-            return { ...state, maxCap };
+            state.vdd = vdd;
         },
-        resetVoltageMaxCapForPPK1(state) {
-            state.maxCap = 3600;
+        updateVoltageRegulatorMaxCapPPK1(
+            state,
+            { payload: newMaxCap }: PayloadAction<number>
+        ) {
+            persistVoltageRegulatorMaxCapPPK1(newMaxCap);
+            state.maxCap = newMaxCap;
+            state.maxCapPPK2 = newMaxCap;
+        },
+
+        updateVoltageRegulatorMaxCapPPK2(
+            state,
+            { payload: newMaxCap }: PayloadAction<number>
+        ) {
+            persistVoltageRegulatorMaxCapPPK2(newMaxCap);
+            state.maxCap = newMaxCap;
+            state.maxCapPPK2 = newMaxCap;
         },
     },
 });
@@ -75,10 +94,11 @@ export const voltageRegulatorState = (state: RootState) =>
     state.app.voltageRegulator;
 
 export const {
-    moveVoltageRegulatorVddAction,
-    updateRegulatorAction,
-    updateVoltageRegulatorMaxCapAction,
-    resetVoltageMaxCapForPPK1,
+    updateRegulator,
+    updateMaxCapOnDeviceSelected,
+    moveVoltageRegulatorVdd,
+    updateVoltageRegulatorMaxCapPPK1,
+    updateVoltageRegulatorMaxCapPPK2,
 } = voltageRegulatorSlice.actions;
 
 export default voltageRegulatorSlice.reducer;

--- a/src/slices/voltageRegulatorSlice.ts
+++ b/src/slices/voltageRegulatorSlice.ts
@@ -65,6 +65,9 @@ const voltageRegulatorSlice = createSlice({
             setVoltageRegulatorMaxCap(maxCap);
             return { ...state, maxCap };
         },
+        resetVoltageMaxCapForPPK1(state) {
+            state.maxCap = 3600;
+        },
     },
 });
 
@@ -75,6 +78,7 @@ export const {
     moveVoltageRegulatorVddAction,
     updateRegulatorAction,
     updateVoltageRegulatorMaxCapAction,
+    resetVoltageMaxCapForPPK1,
 } = voltageRegulatorSlice.actions;
 
 export default voltageRegulatorSlice.reducer;

--- a/src/usageDataActions.ts
+++ b/src/usageDataActions.ts
@@ -7,6 +7,8 @@
 const EventAction = {
     BUFFER_SIZE_CHANGED: 'Sampling buffer size changed',
     VOLTAGE_MAX_LIMIT_CHANGED: 'Max voltage limit changed',
+    VOLTAGE_MAX_LIMIT_RESET:
+        'Max Voltage limit changed because PPK1 was selected',
     PPK_1_SELECTED: 'PPK1 selected',
     PPK_2_SELECTED: 'PPK2 selected',
     Y_MIN_SET_EXPLICITLY: 'YMin was explicitly changed',

--- a/src/utils/persistentStore.ts
+++ b/src/utils/persistentStore.ts
@@ -19,7 +19,8 @@ const DIGITAL_CHANNELS_VISIBLE = 'digitalChannelsVisible';
 const DIGITAL_CHANNELS = 'digitalChannels';
 const TIMESTAMPS_VISIBLE = 'timestampsVisible';
 const MAX_BUFFER_SIZE = 'maxBufferSize';
-const VOLTAGE_REGULATOR_MAX_CAP = 'voltageRegulatorMaxCap';
+const VOLTAGE_REGULATOR_MAX_CAP_PPK1 = 'voltageRegulatorMaxCapPPK1';
+const VOLTAGE_REGULATOR_MAX_CAP_PPK2 = 'voltageRegulatorMaxCap';
 
 type SAMPLE_FREQUENCY = `sampleFreq-${number}`;
 type DURATION_SECONDS = `durationSeconds-${number}`;
@@ -52,7 +53,7 @@ interface StoreSchema {
     [TIMESTAMPS_VISIBLE]: boolean;
 
     [MAX_BUFFER_SIZE]: number;
-    [VOLTAGE_REGULATOR_MAX_CAP]: number;
+    [VOLTAGE_REGULATOR_MAX_CAP_PPK2]: number;
 
     [maxSampleFrequency: SAMPLE_FREQUENCY]: number;
     [maxSampleFrequency: DURATION_SECONDS]: number;
@@ -123,7 +124,11 @@ export const getMaxBufferSize = (defaultMaxBufferSize: number) => {
 export const setMaxBufferSize = (maxBufferSize: number) =>
     store<StoreSchema>().set(MAX_BUFFER_SIZE, maxBufferSize);
 
-export const getVoltageRegulatorMaxCap = (defaultMaxCap: number) =>
-    store<StoreSchema>().get(VOLTAGE_REGULATOR_MAX_CAP, defaultMaxCap);
-export const setVoltageRegulatorMaxCap = (maxCap: number) =>
-    store<StoreSchema>().set(VOLTAGE_REGULATOR_MAX_CAP, maxCap);
+export const getVoltageRegulatorMaxCapPPK1 = (defaultMaxCap: number) =>
+    store<StoreSchema>().get(VOLTAGE_REGULATOR_MAX_CAP_PPK1, defaultMaxCap);
+export const setVoltageRegulatorMaxCapPPK1 = (maxCap: number) =>
+    store<StoreSchema>().set(VOLTAGE_REGULATOR_MAX_CAP_PPK1, maxCap);
+export const getVoltageRegulatorMaxCapPPK2 = (defaultMaxCap: number) =>
+    store<StoreSchema>().get(VOLTAGE_REGULATOR_MAX_CAP_PPK2, defaultMaxCap);
+export const setVoltageRegulatorMaxCapPPK2 = (maxCap: number) =>
+    store<StoreSchema>().set(VOLTAGE_REGULATOR_MAX_CAP_PPK2, maxCap);


### PR DESCRIPTION
This is the first Pull Request in a series of PR's to come. The motivation is to convert as much code to TypeScript as possible in order to make the code more readable, so that we can make improvements in the future. If I notice improvements, that are not too demanding, I will attempt to make them along the way, and include them under **Functional Changes**.

### TypeScript Conversions

- [Convert DeviceSelector to typescript](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/commit/efe961f4b3b032ff6104755b8256532696fc702b)
- [Convert BufferSettings component to typescript](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/commit/376cd7290b43247915d9c943e6c2c187425aefd3)
- [Change CapVoltageSettings to typescript](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/commit/ad30089f338f0fae5b42070904e01bc38b55ee4f)
- [Convert ChartTop to typescript](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/commit/1328af5dfa6f4bdf3ab1284a04eea2b073eb9f56)

### Functional Changes

- [Only dispatch a buffer size change on reload](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/commit/f3c719f55a857ea76fdd698ac3c5f3001a4f2ba4)
- [Reduce maxVoltageCap when PPK1 is selected](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/commit/421cafdc3a67bb1072086be42dab6d2e2abb2493)
- [Fix: Voltage regulator cap on PPK1](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/commit/1bf95eef25667b6ee45f6193c353ef782f5d758e)