### PR TITLE
Fix/do not clear sample

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,8 @@
 
 ## Fixed
 
+-   When changing the sampling parameters in the side panel, after having done a
+    sample, it would remove the sample data.
 -   Zooming further than what is permitted would cause the graph to pane. This
     is now restricted, which means that if zooming has reached its limit, you
     will need to explicitly pane the graph.

--- a/src/actions/deviceActions.ts
+++ b/src/actions/deviceActions.ts
@@ -75,21 +75,13 @@ export const setupOptions =
 
                 setSamplingRate(newSamplesPerSecond);
                 initializeDataBuffer(realtimeWindowDuration);
-                if (device.capabilities.ppkSetPowerMode) {
-                    initializeBitsBuffer(realtimeWindowDuration);
-                } else {
-                    removeBitsBuffer();
-                }
+                initializeBitsBuffer(realtimeWindowDuration);
             } else {
                 const { durationSeconds, sampleFreq } =
                     getState().app.dataLogger;
                 setSamplingRate(sampleFreq);
                 initializeDataBuffer(durationSeconds);
-                if (device.capabilities.ppkSetPowerMode) {
-                    initializeBitsBuffer(durationSeconds);
-                } else {
-                    removeBitsBuffer();
-                }
+                initializeBitsBuffer(durationSeconds);
             }
             options.index = 0;
             options.timestamp = 0;

--- a/src/actions/deviceActions.ts
+++ b/src/actions/deviceActions.ts
@@ -18,7 +18,6 @@ import {
     initializeBitsBuffer,
     initializeDataBuffer,
     options,
-    removeBitsBuffer,
     setSamplingRate,
     updateTitle,
 } from '../globals';
@@ -114,6 +113,9 @@ export function samplingStart() {
                 : EventAction.START_DATA_LOGGER_SAMPLE
         );
         usageData.sendUsageData(EventAction.SAMPLE_STARTED_WITH_PPK2_SELECTED);
+
+        // Prepare global options
+        dispatch(setupOptions());
 
         options.data.fill(NaN);
         if (options.bits) {

--- a/src/components/Chart/data/dataAccumulator.ts
+++ b/src/components/Chart/data/dataAccumulator.ts
@@ -59,6 +59,7 @@ export default (): DataAccumulator => ({
 
         const originalIndexBegin = timestampToIndex(begin);
         const originalIndexEnd = timestampToIndex(end);
+
         const step =
             len === 0 ? 0 : (originalIndexEnd - originalIndexBegin) / len;
 

--- a/src/components/SidePanel/StartStop.tsx
+++ b/src/components/SidePanel/StartStop.tsx
@@ -4,18 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { useCallback } from 'react';
+import React from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { useDispatch, useSelector } from 'react-redux';
 import { unit } from 'mathjs';
 import { Group, Slider } from 'pc-nrfconnect-shared';
 
-import {
-    samplingStart,
-    samplingStop,
-    setupOptions,
-} from '../../actions/deviceActions';
+import { samplingStart, samplingStop } from '../../actions/deviceActions';
 import { appState } from '../../slices/appSlice';
 import {
     dataLoggerState,
@@ -48,11 +44,6 @@ export default () => {
 
     const startStopTitle = !samplingRunning ? startButtonTooltip : undefined;
 
-    const completeChange = useCallback(
-        () => dispatch(setupOptions()),
-        [dispatch]
-    );
-
     return (
         <Group heading="Sampling parameters">
             <div className={samplingRunning ? 'disabled' : ''}>
@@ -73,7 +64,7 @@ export default () => {
                                     })
                                 ),
                         ]}
-                        onChangeComplete={completeChange}
+                        onChangeComplete={() => {}}
                     />
                 </div>
                 <NumberWithUnit
@@ -85,7 +76,7 @@ export default () => {
                     onChange={(v: number) =>
                         dispatch(updateDurationSeconds({ durationSeconds: v }))
                     }
-                    onChangeComplete={completeChange}
+                    onChangeComplete={() => {}}
                     slider
                 />
             </div>


### PR DESCRIPTION
Issue: After running  a sample, changing the _Sampling Parameters_ in the Side Panel, would remove the entire sample.

This PR resolved the issue by postponing changes to the sample buffers,  e.g. `options.data`, until the user starts a new sample. First when a sample has been started the initialization of the new buffers are executed, together with resetting the state of the `options` object.