### PR TITLE
Continue Live when pressing chart top buttons

### DIFF
--- a/src/components/Chart/Chart.tsx
+++ b/src/components/Chart/Chart.tsx
@@ -303,6 +303,10 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
      */
     const zoomToWindow = useCallback(
         localWindowDuration => {
+            if (windowBegin === 0 && windowEnd === 0) {
+                chartReset(localWindowDuration);
+                return;
+            }
             if (windowBegin != null && windowEnd != null) {
                 const center = (windowBegin + windowEnd) / 2;
                 let localWindowBegin = center - localWindowDuration / 2;


### PR DESCRIPTION
When adjusting the window width using the predefined widths in Chart Top, continue the live view while sampling.