### PR TITLE
fix: The chart repeated itself when zooming out

### DIFF
--- a/src/components/Chart/data/dataAccumulator.ts
+++ b/src/components/Chart/data/dataAccumulator.ts
@@ -80,7 +80,7 @@ export default (): DataAccumulator => ({
             let max: number | undefined = -Number.MAX_VALUE;
 
             for (let n = k; n < l; ++n) {
-                let v = data[n];
+                let v = data[n] ?? NaN;
 
                 if (removeZeroValues && v === 0) {
                     v = NaN;

--- a/src/components/Chart/data/dataAccumulator.ts
+++ b/src/components/Chart/data/dataAccumulator.ts
@@ -80,8 +80,7 @@ export default (): DataAccumulator => ({
             let max: number | undefined = -Number.MAX_VALUE;
 
             for (let n = k; n < l; ++n) {
-                const ni = (n + data.length) % data.length;
-                let v = data[ni];
+                let v = data[n];
 
                 if (removeZeroValues && v === 0) {
                     v = NaN;
@@ -91,7 +90,7 @@ export default (): DataAccumulator => ({
                     if (v > max) max = v;
                     if (v < min) min = v;
 
-                    bitDataProcessor.processBits(ni);
+                    bitDataProcessor.processBits(n);
                 }
             }
 
@@ -99,6 +98,7 @@ export default (): DataAccumulator => ({
                 min = undefined;
                 max = undefined;
             }
+
             this.ampereLineData[mappedIndex].x = timestamp;
             this.ampereLineData[mappedIndex].y = min;
             ++mappedIndex;


### PR DESCRIPTION
To reproduce, you would sample for just a few seconds, on for example 1000 samples per second, and when you zoomed out, it would show the same chart repeated across the window.

The logic that seemed to produce this bug is a remains from when the app used a circular buffer in order to store the samples.