### PR TITLE
fix: Minimap was not properly removed

### DIFF
--- a/src/components/Chart/Chart.tsx
+++ b/src/components/Chart/Chart.tsx
@@ -454,7 +454,7 @@ const Chart = ({ digitalChannelsEnabled = false }) => {
                     cursorEnd={cursorEnd}
                     width={chartAreaWidth + 1}
                 />
-                <Minimap />
+                {isDataLoggerPane ? <Minimap /> : null}
                 <div
                     className="chart-bottom"
                     style={{ paddingRight: `${rightMargin}px` }}

--- a/src/features/minimap/Minimap.tsx
+++ b/src/features/minimap/Minimap.tsx
@@ -73,6 +73,10 @@ const Minimap = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [showMinimap, canvasRef.current?.style.display]);
 
+    const hasGeneratedMinimap =
+        minimapRef.current != null &&
+        minimapRef.current?.data.datasets[0].data.length > 0;
+
     return (
         <div
             className="tw-relative tw-h-28 tw-w-full tw-py-4"
@@ -82,17 +86,14 @@ const Minimap = () => {
                 paddingRight: '1.8rem',
             }}
         >
-            {options.index === 0 ||
-            minimapRef.current?.data.datasets[0].data.length === 0
-                ? MinimapDefaultState()
-                : null}
+            {hasGeneratedMinimap ? null : MinimapDefaultState()}
             <canvas
                 ref={canvasRef}
                 id="minimap"
                 className="tw-max-h-20 tw-w-full tw-border tw-border-solid"
                 style={{
                     borderColor: colors.gray100,
-                    display: options.index === 0 ? 'none' : 'block',
+                    display: hasGeneratedMinimap ? 'block' : 'none',
                 }}
             />
             <div


### PR DESCRIPTION
Make sure that the minimap is properly hidden/removed when you do multiple samples.

The bug was present because we only checked if the options.data had entries, but we need to make sure a minimap is actually generated before displaying the minimap.

This commit also makes sure that the Minimap is only rendered if the App is rendering the Data Logger pane, as this functionality should not be present in the Real Time pane.