### PR TITLE
fix: SELECTION statistics with negative time delta

### DIFF
--- a/src/components/Chart/data/dataAccumulator.ts
+++ b/src/components/Chart/data/dataAccumulator.ts
@@ -27,6 +27,13 @@ export const calcStats = (begin?: null | number, end?: null | number) => {
         return null;
     }
 
+    if (begin > end) {
+        const temp = begin;
+        begin = end;
+        end = temp;
+    }
+
+    begin = Math.max(begin, 0);
     end = Math.min(end, DataManager().getTimestamp());
 
     const data = DataManager().getData(begin, end);


### PR DESCRIPTION
fixes: [NCD-574](https://nordicsemi.atlassian.net/browse/NCD-574?atlOrigin=eyJpIjoiZjc3OWI3NmQ0NTJmNDA3MzhlN2I3MmFmNWZkNzk0NTgiLCJwIjoiaiJ9)

On using the right handle to adjust the selection, you could drag it passed the left handle, making the time negative. This commit makes sure that `begin < end`, so that the delta is always `> 0`.

Additionally, you could extend the left handle (=begin) passed 0 on the X axis, so that you could make a SELECTION that would be larger than the data set. Hence begin should always be `>= 0`.