### PR TITLE
Fix for recovery on crash on a darwin platform

### DIFF
--- a/src/features/recovery/RecoveryManager.ts
+++ b/src/features/recovery/RecoveryManager.ts
@@ -201,7 +201,9 @@ export class RecoveryManager {
             } else if (platform === 'linux') {
                 command = `pgrep -f ${processName}`;
             } else if (platform === 'darwin') {
-                command = `pgrep -f ${processName.replace('(Renderer)', '').trim()}`
+                command = `pgrep -f ${processName
+                    .replace('(Renderer)', '')
+                    .trim()}`;
             } else {
                 reject(new Error(`Unsupported platform: ${platform}`));
                 return;

--- a/src/features/recovery/RecoveryManager.ts
+++ b/src/features/recovery/RecoveryManager.ts
@@ -198,8 +198,10 @@ export class RecoveryManager {
 
             if (platform === 'win32') {
                 command = `tasklist | findstr "nRF electron"`;
-            } else if (platform === 'linux' || platform === 'darwin') {
+            } else if (platform === 'linux') {
                 command = `pgrep -f ${processName}`;
+            } else if (platform === 'darwin') {
+                command = `pgrep -f ${processName.replace('(Renderer)', '').trim()}`
             } else {
                 reject(new Error(`Unsupported platform: ${platform}`));
                 return;


### PR DESCRIPTION
`pgrep -f "nRF Connect for Desktop Helper (Renderer)"` won't work so reducing command to `pgrep -f "nRF Connect for Desktop Helper"`

Might be not a best way to fix, please review 