### PR TITLE
Refactor/auto remove ppk2 sessions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,8 @@
 
 ### Added
 
--   Session recovery: option to recover a session after a crash or unexpected
-    shutdown.
+-   Session recovery feature, which lets you recover a session after a crash or
+    an unexpected shutdown.
 
 ## 4.2.1 - 2024-11-11
 

--- a/src/actions/fileActions.ts
+++ b/src/actions/fileActions.ts
@@ -26,7 +26,10 @@ import {
     showProgressDialog,
     updateProgress,
 } from '../features/ProgressDialog/progressSlice';
-import { ChangeSessionStatus } from '../features/recovery/SessionsListFileHandler';
+import {
+    ChangeSessionStatus,
+    SessionFlag,
+} from '../features/recovery/SessionsListFileHandler';
 import { DataManager } from '../globals';
 import type { RootState } from '../slices';
 import {
@@ -110,7 +113,7 @@ export const save =
             const sessionPath = DataManager().getSessionFolder();
             if (sessionPath) {
                 const filePath = join(sessionPath, 'session.raw');
-                ChangeSessionStatus(filePath, true);
+                ChangeSessionStatus(filePath, SessionFlag.Recovered);
             }
 
             dispatch(setSavePending(false));

--- a/src/features/recovery/RecoveryDialogs.tsx
+++ b/src/features/recovery/RecoveryDialogs.tsx
@@ -29,6 +29,7 @@ import {
     DeleteAllSessions,
     RemoveSessionByFilePath,
     Session,
+    SessionFlag,
 } from './SessionsListFileHandler';
 
 const SessionItem = ({
@@ -40,48 +41,34 @@ const SessionItem = ({
     onRecoverClick: (session: Session) => void;
     onRemoveClick: (session: Session) => void;
 }) => (
-    <div className="tw-flex tw-flex-col tw-justify-end tw-gap-11 tw-bg-gray-800 tw-p-3 tw-text-white">
-        <div className="tw-flex tw-flex-grow tw-flex-col tw-justify-between tw-gap-2">
-            <div className="tw-flex tw-flex-row tw-justify-between">
-                <div>
-                    <div className="tw-text-xs">Start time</div>
-                    <div>{formatTimestamp(session.startTime)}</div>
-                </div>
-                <div>
-                    <div className="tw-text-xs">Duration</div>
-                    <div>{formatDuration(session.samplingDuration || 0)}</div>
-                </div>
-                <div>
-                    <div className="tw-text-xs">Sampling rate</div>
-                    <div>{session.samplingRate}</div>
-                </div>
-                <div className="tw-content-center tw-align-middle">
-                    <div className="tw-flex tw-flex-row tw-gap-2">
-                        <Button
-                            variant="secondary"
-                            onClick={() => onRemoveClick(session)}
-                        >
-                            Delete
-                        </Button>
-                        <Button
-                            variant="primary"
-                            className="tw-w-[60px]"
-                            onClick={() => onRecoverClick(session)}
-                        >
-                            {session.alreadyRecovered ? 'Load' : 'Recover'}
-                        </Button>
-                    </div>
-                </div>
+    <div className=" tw-flex tw-flex-row tw-justify-between tw-bg-gray-800 tw-p-3 tw-text-white">
+        <div>
+            <div className="tw-text-xs">Start time</div>
+            <div>{formatTimestamp(session.startTime)}</div>
+        </div>
+        <div>
+            <div className="tw-text-xs">Duration</div>
+            <div>{formatDuration(session.samplingDuration || 0)}</div>
+        </div>
+        <div>
+            <div className="tw-text-xs">Sampling rate</div>
+            <div>{session.samplingRate}</div>
+        </div>
+        <div className="tw-content-center tw-align-middle">
+            <div className="tw-flex tw-flex-row tw-gap-2">
+                <Button
+                    variant="secondary"
+                    onClick={() => onRemoveClick(session)}
+                >
+                    Delete
+                </Button>
+                <Button
+                    variant="primary"
+                    onClick={() => onRecoverClick(session)}
+                >
+                    Recover
+                </Button>
             </div>
-            {session.alreadyRecovered && (
-                <div className="tw-flex tw-flex-row tw-gap-1 tw-text-orange-400">
-                    <span className="mdi mdi-information-outline info-icon" />
-                    <span className="tw-grid tw-items-center tw-text-xs">
-                        The session has already been recovered or loaded by
-                        using a ppk2 file. You can load it again or delete it.
-                    </span>
-                </div>
-            )}
         </div>
     </div>
 );
@@ -158,7 +145,7 @@ export default () => {
                 addConfirmBeforeClose({
                     id: 'sessionRecoveryInProgress',
                     message:
-                        'There is a session recovery in progress. If you close the application the recovery progress will be lost and the session will remain in the recovery list. Are you sure you want to close?',
+                        'There is a session recovery in progress. If you close the application, the progress will be lost and the session will remain in the recovery list. Are you sure you want to close?',
                 })
             );
         } else {
@@ -227,14 +214,15 @@ export default () => {
             >
                 <>
                     <div className="tw-mb-4">
-                        The following sessions can be recovered:
+                        The following sampling sessions did not close properly
+                        and can be recovered:
                     </div>
                     <div className="core19-app tw-max-h-96 tw-overflow-y-auto tw-bg-white">
                         <ItemizedSessions
                             orphanedSessions={orphanedSessions}
                             onRecoverClick={session => {
                                 setIsSessionsListDialogVisible(false);
-                                if (session.alreadyRecovered) {
+                                if (session.flag === SessionFlag.Recovered) {
                                     dispatch(
                                         RecoveryManager.renderSessionData(
                                             session

--- a/src/features/recovery/RecoveryManager.ts
+++ b/src/features/recovery/RecoveryManager.ts
@@ -44,7 +44,9 @@ import {
 import {
     ChangeSessionStatus,
     ReadSessions,
+    RemoveSessionByFilePath,
     Session,
+    SessionFlag,
     WriteSessions,
 } from './SessionsListFileHandler';
 
@@ -144,7 +146,7 @@ export class RecoveryManager {
                     session.startTime
                 );
 
-                ChangeSessionStatus(session.filePath, true);
+                ChangeSessionStatus(session.filePath, SessionFlag.Recovered);
 
                 await dispatch(RecoveryManager.renderSessionData(session));
             } catch (error) {
@@ -407,7 +409,11 @@ export class RecoveryManager {
                 RecoveryManager.#getSamplingDurationInSec(session);
 
             if (!processList.includes(Number(session.pid))) {
-                orphanedSessions.push(session);
+                if (session.flag === SessionFlag.PPK2Loaded) {
+                    RemoveSessionByFilePath(session.filePath, () => {});
+                } else {
+                    orphanedSessions.push(session);
+                }
             }
 
             onProgress(((index + 1) / sessions.length) * 100);

--- a/src/utils/FileBuffer.ts
+++ b/src/utils/FileBuffer.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import {
     AddSession,
     RemoveSessionByFilePath,
+    SessionFlag,
 } from '../features/recovery/SessionsListFileHandler';
 import {
     fullOverlap,
@@ -127,7 +128,7 @@ export class FileBuffer {
                 AddSession(
                     Date.now(),
                     this.samplingRate ? this.samplingRate : 100000,
-                    false,
+                    SessionFlag.NotRecovered,
                     this.#filePath
                 );
             }

--- a/src/utils/__tests__/fileBuffer.test.ts
+++ b/src/utils/__tests__/fileBuffer.test.ts
@@ -15,6 +15,11 @@ jest.mock('../../features/recovery/SessionsListFileHandler', () => ({
     AddSession: jest.fn(),
     RemoveSessionByFilePath: jest.fn(),
     ClearSessions: jest.fn(),
+    SessionFlag: {
+        NotRecovered: 0,
+        Recovered: 1,
+        PPK2Loaded: 2,
+    },
 }));
 
 jest.mock('fs-extra', () => ({

--- a/src/utils/loadFileHandler.ts
+++ b/src/utils/loadFileHandler.ts
@@ -19,7 +19,10 @@ import { v4 } from 'uuid';
 import { createInflateRaw } from 'zlib';
 
 import { startPreventSleep, stopPreventSleep } from '../features/preventSleep';
-import { AddSession } from '../features/recovery/SessionsListFileHandler';
+import {
+    AddSession,
+    SessionFlag,
+} from '../features/recovery/SessionsListFileHandler';
 import { DataManager, timestampToIndex } from '../globals';
 import { canFileFit } from './fileUtils';
 import saveFile, { PPK2Metadata } from './saveFileHandler';
@@ -247,7 +250,7 @@ const loadPPK2File = async (
         AddSession(
             metadata.metadata.startSystemTime ?? Date.now(),
             metadata.metadata.samplesPerSecond,
-            true,
+            SessionFlag.PPK2Loaded,
             sessionFilePath
         );
 


### PR DESCRIPTION
Changes:
- Added an extra flag for "Session loaded by ppk2" in .ppksess file.
- The sessions loaded by using .ppk2 are automatically deleted on start;
- The additional text for pointing that a session has been already recovered is removed;
- User will see "Recover" button instead of "Load" if the session has been recovered before. However, the session will still not be recovered from scratch, but just loaded.