### PR TITLE
Add some recovery error handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ### Fixed
 
--   Scenarios where session files become unavailable during recovery operations.
+-   Issue with scenarios where session files would become unavailable during
+    recovery operations.
 
 ## 4.3.0 - 2025-07-31
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 4.3.1 - UNRELEASED
+
+### Fixed
+
+-   Scenarios where session files become unavailable during recovery operations.
+
 ## 4.3.0 - 2025-07-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-ppk",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "displayName": "Power Profiler",
     "description": "App for use with Nordic Power Profiler Kits",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-ppk",

--- a/src/features/recovery/RecoveryDialogs.tsx
+++ b/src/features/recovery/RecoveryDialogs.tsx
@@ -275,10 +275,19 @@ export default () => {
                                         ) {
                                             dispatch(
                                                 RecoveryManager.renderSessionData(
-                                                    session
+                                                    session,
+                                                    () => {
+                                                        dispatch(
+                                                            setSavePending(true)
+                                                        );
+                                                    },
+                                                    error => {
+                                                        logger.error(
+                                                            error.message
+                                                        );
+                                                    }
                                                 )
                                             );
-                                            dispatch(setSavePending(true));
                                             return;
                                         }
                                         setIsRecovering(true);
@@ -301,11 +310,12 @@ export default () => {
                                                     );
                                                 },
                                                 (error: Error) => {
-                                                    pause();
-                                                    setRecoveryError(
-                                                        error.message
-                                                    );
                                                     logger.error(error.message);
+                                                    pause();
+                                                    setIsRecovering(false);
+                                                    dispatch(
+                                                        setSavePending(false)
+                                                    );
                                                 },
                                                 pause
                                             )

--- a/src/features/recovery/RecoveryManager.ts
+++ b/src/features/recovery/RecoveryManager.ts
@@ -147,7 +147,7 @@ export class RecoveryManager {
                     );
                 } else {
                     onFail?.(
-                        new Error('Unknown error while rendering session.')
+                        new Error('Unknown error while rendering the session.')
                     );
                 }
             }

--- a/src/features/recovery/RecoveryManager.ts
+++ b/src/features/recovery/RecoveryManager.ts
@@ -92,45 +92,64 @@ export class RecoveryManager {
     }
 
     static renderSessionData =
-        (session: Session): AppThunk<RootState, Promise<void>> =>
+        (
+            session: Session,
+            onComplete?: () => void,
+            onFail?: (error: Error) => void
+        ): AppThunk<RootState, Promise<void>> =>
         async (dispatch, getState) => {
-            const sessionPath = path.dirname(session.filePath);
+            try {
+                const sessionPath = path.dirname(session.filePath);
 
-            await DataManager().reset();
-            dispatch(resetChartTime());
-            dispatch(resetMinimap());
-            dispatch(setLiveMode(false));
-            dispatch(resetCursor());
+                await DataManager().reset();
+                dispatch(resetChartTime());
+                dispatch(resetMinimap());
+                dispatch(setLiveMode(false));
+                dispatch(resetCursor());
 
-            await DataManager().setSamplesPerSecond(session.samplingRate);
-            await DataManager().loadData(sessionPath, session.startTime);
+                await DataManager().setSamplesPerSecond(session.samplingRate);
+                await DataManager().loadData(sessionPath, session.startTime);
 
-            const timestamp = DataManager().getTimestamp();
+                const timestamp = DataManager().getTimestamp();
 
-            dispatch(setCurrentPane(Panes.DATA_LOGGER));
+                dispatch(setCurrentPane(Panes.DATA_LOGGER));
 
-            if (timestamp) {
-                dispatch(setLatestDataTimestamp(timestamp));
-                dispatch(
-                    updateSampleFreqLog10({
-                        sampleFreqLog10: Math.log10(
-                            DataManager().getSamplesPerSecond()
-                        ),
-                    })
-                );
-                if (
-                    DataManager().getTimestamp() <=
-                    getWindowDuration(getState())
-                ) {
+                if (timestamp) {
+                    dispatch(setLatestDataTimestamp(timestamp));
                     dispatch(
-                        chartWindowAction(0, DataManager().getTimestamp())
+                        updateSampleFreqLog10({
+                            sampleFreqLog10: Math.log10(
+                                DataManager().getSamplesPerSecond()
+                            ),
+                        })
+                    );
+                    if (
+                        DataManager().getTimestamp() <=
+                        getWindowDuration(getState())
+                    ) {
+                        dispatch(
+                            chartWindowAction(0, DataManager().getTimestamp())
+                        );
+                    } else {
+                        dispatch(scrollToEnd());
+                    }
+                    dispatch(triggerForceRerenderMainChart());
+                    dispatch(triggerForceRerenderMiniMap());
+                    dispatch(miniMapAnimationAction());
+                }
+                onComplete?.();
+            } catch (error) {
+                if (error instanceof Error) {
+                    onFail?.(
+                        new Error(
+                            `Failed to render the session: ${error.message}`
+                        )
                     );
                 } else {
-                    dispatch(scrollToEnd());
+                    onFail?.(
+                        new Error('Unknown error while rendering session.')
+                    );
                 }
-                dispatch(triggerForceRerenderMainChart());
-                dispatch(triggerForceRerenderMiniMap());
-                dispatch(miniMapAnimationAction());
             }
         };
 
@@ -272,6 +291,12 @@ export class RecoveryManager {
 
             const sessionFilePath = session.filePath;
             const sessionPath = path.dirname(sessionFilePath);
+
+            if (!fs.existsSync(sessionFilePath)) {
+                dispatch(setSessionRecoveryPending(false));
+                onFail(new Error(`Session file not found: ${sessionFilePath}`));
+                return;
+            }
 
             const stats = await stat(sessionFilePath);
 


### PR DESCRIPTION
Fixes: https://nordicsemi.atlassian.net/browse/NCD-1406

<img width="834" height="213" alt="Screenshot_1" src="https://github.com/user-attachments/assets/8b5987a8-4e37-4d6e-8361-9931c203016a" />


Also handles a use case when:
A recovery process of a big/long session is started. During the process the external drive with the session.raw file is removed. This will log an error after a couple of seconds.