### PR TITLE
Bump nrfutil-core to 8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
                 "2.10.2"
             ]
         },
-        "nrfutilCore": "8.0.0"
+        "nrfutilCore": "8.1.1"
     },
     "engines": {
         "nrfconnect": ">=5.2.0"


### PR DESCRIPTION
Bump nrfutil-core to 8.1.1. Because https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/issues/1189 showed that it is necessary for some users.