### PR TITLE
chore: point workflows and package URLs to nordicsemi org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
     build:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/build-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/build-app.yml@main

--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     create-doc-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
         with:
             bundle-name: nrf-connect-ppk

--- a/.github/workflows/docs-publish-dev.yml
+++ b/.github/workflows/docs-publish-dev.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-ppk
             release-type: dev

--- a/.github/workflows/docs-publish-prod.yml
+++ b/.github/workflows/docs-publish-prod.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-ppk
             release-type: prod

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
     check_labels:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/labels.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/labels.yml@main
         secrets: inherit

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: latest (internal)
         secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: ${{ inputs.source }}
             ref: ${{ inputs.ref }}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ user application.
 The support for
 [Power Profiler Kit (PPK1)](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit)
 has been deprecated since the
-[Power Profiler app v4.0.0-beta1](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/main/Changelog.md).
+[Power Profiler app v4.0.0-beta1](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/main/Changelog.md).
 The last application version to support PPK1 is
-[v3.5.5](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/main/Changelog.md)
+[v3.5.5](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/main/Changelog.md)
 with
-[nRF Connect for Desktop v4.4.0](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/main/Changelog.md).
+[nRF Connect for Desktop v4.4.0](https://github.com/nordicsemi/pc-nrfconnect-launcher/blob/main/Changelog.md).
 
 ## Installation
 
@@ -39,8 +39,7 @@ hardware, see the
 
 ## Development
 
-See the
-[app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/)
+See the [app development](https://nordicsemi.github.io/pc-nrfconnect-docs/)
 pages for details on how to develop apps for the nRF Connect for Desktop
 framework.
 
@@ -51,7 +50,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[infos on contributing](https://nordicsemi.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License
@@ -73,21 +72,21 @@ A ppk2 file is a zip compressed file, containing 3 files:
 Mandatory Data:
 
 - `session.raw` in
-  [class FileData](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/globals.ts#L53-L112)
+  [class FileData](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/globals.ts#L53-L112)
     - 4 bytes for current: decimal in μA
     - 2 bytes for the digital channels: 2 bits per channel, LSB is digital
       channel 1 (D8-D7-D6-D5-D4-D3-D2-D1). Conversion of the 8-bit digital input
       to the 16-bit format is done in
-      [the function `convertBits16`](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/bitConversion.ts#L21)
+      [the function `convertBits16`](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/bitConversion.ts#L21)
 
 - Minimap condensed data in
-  [FoldingBuffer#saveToFile](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/foldingBuffer.ts#L118-L128)
+  [FoldingBuffer#saveToFile](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/foldingBuffer.ts#L118-L128)
 - Metadata stored in
-  [`saveFileHandler`](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/saveFileHandler.ts#L57-L60)
+  [`saveFileHandler`](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/saveFileHandler.ts#L57-L60)
   (samples per second must be the same as supported by our app)
 
 **Important**: No negative values are supported! Any values < 0.2 μA are
 interpreted as 0.
 
 Final compression of the 3 files into ppk2 in
-[`saveFileHandler`](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/saveFileHandler.ts#L40).
+[`saveFileHandler`](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/6e4da637f07d5f6995d96362368c781b71b5bc61/src/utils/saveFileHandler.ts#L40).

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -14,10 +14,10 @@ For installation instructions, see [Installing nRF Connect for Desktop apps](htt
 
 ## Deprecated support
 
-The support for [Power Profiler Kit (PPK1)](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit) has been deprecated since the [Power Profiler app v4.0.0-beta1](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/main/Changelog.md). The last application version to support PPK1 is [v3.5.5](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/main/Changelog.md) with [nRF Connect for Desktop v4.4.0](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/main/Changelog.md).
+The support for [Power Profiler Kit (PPK1)](https://www.nordicsemi.com/Software-and-tools/Development-Tools/Power-Profiler-Kit) has been deprecated since the [Power Profiler app v4.0.0-beta1](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/main/Changelog.md). The last application version to support PPK1 is [v3.5.5](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/main/Changelog.md) with [nRF Connect for Desktop v4.4.0](https://github.com/nordicsemi/pc-nrfconnect-launcher/blob/main/Changelog.md).
 If you use the first version of the hardware, see the [online documentation for PPK1](https://docs.nordicsemi.com/bundle/ug_ppk/page/UG/ppk/PPK_user_guide_Intro.html).
 
 ## Application source code
 
-The code of the application is open source and [available on GitHub](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk).
+The code of the application is open source and [available on GitHub](https://github.com/nordicsemi/pc-nrfconnect-ppk).
 Feel free to fork the repository and clone it for secondary development or feature contributions.

--- a/doc/docs/revision_history.yml
+++ b/doc/docs/revision_history.yml
@@ -20,7 +20,7 @@ sections:
   - "Editorial changes"
 - name: March 2024
   entries:
-  - "Updated the documentation for the Power Profiler app [v4.0.0](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk/blob/main/Changelog.md)"
+  - "Updated the documentation for the Power Profiler app [v4.0.0](https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/main/Changelog.md)"
 - name: February 2024
   entries:
   - "Separated the application documentation from the [PPK2 hardware documentation](https://docs.nordicsemi.com/bundle/ug_ppk2/page/UG/ppk/PPK_user_guide_Intro.html)"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "version": "4.4.0",
     "displayName": "Power Profiler",
     "description": "App for use with Nordic Power Profiler Kits",
-    "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-ppk",
+    "homepage": "https://github.com/nordicsemi/pc-nrfconnect-ppk",
     "repository": {
         "type": "git",
-        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-ppk.git"
+        "url": "https://github.com/nordicsemi/pc-nrfconnect-ppk.git"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",

--- a/src/device/serialDevice.ts
+++ b/src/device/serialDevice.ts
@@ -231,7 +231,7 @@ class SerialDevice extends Device {
             this.dataLossCounter + missingSamples >= DATALOSS_THRESHOLD
         ) {
             logger.error(
-                'Data loss detected. See https://github.com/Nordicsemiconductor/pc-nrfconnect-ppk/blob/main/doc/docs/troubleshooting.md#data-loss-with-ppk2',
+                'Data loss detected. See https://github.com/nordicsemi/pc-nrfconnect-ppk/blob/main/doc/docs/troubleshooting.md#data-loss-with-ppk2',
             );
         }
         this.dataLossCounter += missingSamples;


### PR DESCRIPTION
Update reusable workflow references and repository homepage/URL from NordicSemiconductor to nordicsemi.

## Summary

Updates all reusable workflow `uses:` paths from `NordicSemiconductor/pc-nrfconnect-shared` to `nordicsemi/pc-nrfconnect-shared` to match the enterprise organization naming.

`package.json` `homepage` and `repository.url` point at the canonical **nordicsemi** org (not the former NordicSemiconductor naming).

## Notes

No functional workflow logic changes; only the repository path in composite/reusable workflow references, plus `package.json` metadata for the official GitHub location.