### PR TITLE
fix: event listener leaks slowing down UI

### DIFF
--- a/src/components/Chart/plugins/chart.crossHair.ts
+++ b/src/components/Chart/plugins/chart.crossHair.ts
@@ -20,12 +20,20 @@ interface CrossHairPlugin extends Plugin<'line'> {
     };
     pointerMoveHandler: (event: PointerEvent, chart: AmpereChartJS) => void;
     pointerLeaveHandler: () => void;
+    handlerRegistry: Map<
+        AmpereChartJS,
+        {
+            pointerMoveListener: (event: PointerEvent) => void;
+            pointerLeaveListener: () => void;
+        }
+    >;
 }
 
 const plugin: CrossHairPlugin = {
     id: 'crossHair',
     instances: [],
     moveEvent: null,
+    handlerRegistry: new Map(),
 
     pointerMoveHandler(event, chart) {
         const {
@@ -71,10 +79,17 @@ const plugin: CrossHairPlugin = {
         plugin.instances.push(chart);
 
         const { canvas } = chart.ctx;
-        canvas.addEventListener('pointermove', event =>
-            plugin.pointerMoveHandler(event, chart),
-        );
-        canvas.addEventListener('pointerleave', plugin.pointerLeaveHandler);
+        const pointerMoveListener = (event: PointerEvent) =>
+            plugin.pointerMoveHandler(event, chart);
+        const pointerLeaveListener = () => plugin.pointerLeaveHandler();
+
+        canvas.addEventListener('pointermove', pointerMoveListener);
+        canvas.addEventListener('pointerleave', pointerLeaveListener);
+
+        plugin.handlerRegistry.set(chart, {
+            pointerMoveListener,
+            pointerLeaveListener,
+        });
     },
 
     afterDraw(chart: AmpereChartJS) {
@@ -185,6 +200,21 @@ const plugin: CrossHairPlugin = {
         );
         if (i > -1) {
             plugin.instances.splice(i, 1);
+        }
+
+        const chart = chartInstance as AmpereChartJS;
+        const handlers = plugin.handlerRegistry.get(chart);
+        if (handlers) {
+            const { canvas } = chart.ctx;
+            canvas.removeEventListener(
+                'pointermove',
+                handlers.pointerMoveListener,
+            );
+            canvas.removeEventListener(
+                'pointerleave',
+                handlers.pointerLeaveListener,
+            );
+            plugin.handlerRegistry.delete(chart);
         }
     },
 };

--- a/src/components/Chart/plugins/chart.dragSelect.ts
+++ b/src/components/Chart/plugins/chart.dragSelect.ts
@@ -80,6 +80,36 @@ const plugin: Plugin<'line'> = {
         canvas.addEventListener('pointerleave', dragSelect.pointerUpHandler);
     },
 
+    afterDestroy(chart: AmpereChartJS) {
+        const { canvas } = chart.ctx;
+        const { dragSelect } = chart;
+
+        if (dragSelect) {
+            if (dragSelect.pointerDownHandler) {
+                canvas.removeEventListener(
+                    'pointerdown',
+                    dragSelect.pointerDownHandler,
+                );
+            }
+            if (dragSelect.pointerMoveHandler) {
+                canvas.removeEventListener(
+                    'pointermove',
+                    dragSelect.pointerMoveHandler,
+                );
+            }
+            if (dragSelect.pointerUpHandler) {
+                canvas.removeEventListener(
+                    'pointerup',
+                    dragSelect.pointerUpHandler,
+                );
+                canvas.removeEventListener(
+                    'pointerleave',
+                    dragSelect.pointerUpHandler,
+                );
+            }
+        }
+    },
+
     beforeDraw(chart: AmpereChartJS) {
         const {
             chartArea: { left, right, top, bottom: areaBottom },

--- a/src/components/Chart/plugins/chart.triggerLevel.ts
+++ b/src/components/Chart/plugins/chart.triggerLevel.ts
@@ -27,10 +27,20 @@ interface TriggerLevelPlugin extends Plugin<'line'> {
     pointerDownHandler: (event: PointerEvent, chart: AmpereChartJS) => void;
     pointerMoveHandler: (event: PointerEvent, chart: AmpereChartJS) => void;
     pointerLeaveHandler: (chart: AmpereChartJS) => void;
+    handlerRegistry: Map<
+        AmpereChartJS,
+        {
+            pointerDownListener: (event: PointerEvent) => void;
+            pointerMoveListener: (event: PointerEvent) => void;
+            pointerUpListener: () => void;
+            pointerLeaveListener: () => void;
+        }
+    >;
 }
 
 const plugin: TriggerLevelPlugin = {
     id: 'triggerLevel',
+    handlerRegistry: new Map(),
 
     getCoords(chart: AmpereChartJS) {
         const {
@@ -120,18 +130,46 @@ const plugin: TriggerLevelPlugin = {
     beforeInit(chart: AmpereChartJS) {
         chart.triggerLine = { y: null };
         const { canvas } = chart.ctx;
-        canvas.addEventListener('pointerdown', evt =>
-            plugin.pointerDownHandler(evt, chart),
-        );
-        canvas.addEventListener('pointermove', evt =>
-            plugin.pointerMoveHandler(evt, chart),
-        );
-        canvas.addEventListener('pointerup', () =>
-            plugin.pointerLeaveHandler(chart),
-        );
-        canvas.addEventListener('pointerleave', () =>
-            plugin.pointerLeaveHandler(chart),
-        );
+
+        const pointerDownListener = (evt: PointerEvent) =>
+            plugin.pointerDownHandler(evt, chart);
+        const pointerMoveListener = (evt: PointerEvent) =>
+            plugin.pointerMoveHandler(evt, chart);
+        const pointerUpListener = () => plugin.pointerLeaveHandler(chart);
+        const pointerLeaveListener = () => plugin.pointerLeaveHandler(chart);
+
+        canvas.addEventListener('pointerdown', pointerDownListener);
+        canvas.addEventListener('pointermove', pointerMoveListener);
+        canvas.addEventListener('pointerup', pointerUpListener);
+        canvas.addEventListener('pointerleave', pointerLeaveListener);
+
+        plugin.handlerRegistry.set(chart, {
+            pointerDownListener,
+            pointerMoveListener,
+            pointerUpListener,
+            pointerLeaveListener,
+        });
+    },
+
+    afterDestroy(chart: AmpereChartJS) {
+        const handlers = plugin.handlerRegistry.get(chart);
+        if (handlers) {
+            const { canvas } = chart.ctx;
+            canvas.removeEventListener(
+                'pointerdown',
+                handlers.pointerDownListener,
+            );
+            canvas.removeEventListener(
+                'pointermove',
+                handlers.pointerMoveListener,
+            );
+            canvas.removeEventListener('pointerup', handlers.pointerUpListener);
+            canvas.removeEventListener(
+                'pointerleave',
+                handlers.pointerLeaveListener,
+            );
+            plugin.handlerRegistry.delete(chart);
+        }
     },
 
     afterDraw(chart: AmpereChartJS) {

--- a/src/components/Chart/plugins/chart.zoomPan.ts
+++ b/src/components/Chart/plugins/chart.zoomPan.ts
@@ -513,6 +513,39 @@ const plugin: Plugin<'line'> = {
             false,
         );
     },
+
+    afterDestroy(chart: AmpereChartJS) {
+        const { canvas } = chart.ctx;
+        const { zoomPan } = chart;
+
+        if (zoomPan) {
+            if (zoomPan.wheelHandler) {
+                canvas.removeEventListener('wheel', zoomPan.wheelHandler);
+            }
+            if (zoomPan.pointerDownHandler) {
+                canvas.removeEventListener(
+                    'pointerdown',
+                    zoomPan.pointerDownHandler,
+                );
+            }
+            if (zoomPan.pointerMoveHandler) {
+                canvas.removeEventListener(
+                    'pointermove',
+                    zoomPan.pointerMoveHandler,
+                );
+            }
+            if (zoomPan.pointerUpHandler) {
+                canvas.removeEventListener(
+                    'pointerup',
+                    zoomPan.pointerUpHandler,
+                );
+                canvas.removeEventListener(
+                    'pointerleave',
+                    zoomPan.pointerUpHandler,
+                );
+            }
+        }
+    },
 };
 
 export default plugin;


### PR DESCRIPTION
I dusted off my nRF PPK and installed the latest Power Profiler software.  I was previously using 3.x and was able to monitor a DUT for hours.

This turned into only a few minutes with 4.3.1.  I noticed clicking around the UI while monitoring seemed to slow things down until the Live View FPS dropped to 1 FPS.

A quick diff shows that a number of removeListeners were dropped in the migration to TypeScript.  Let's fix that.

Attached is a screenshot of my DUT running underneath latest main plus my patch for well over an hour.

<img width="1918" height="1199" alt="Screenshot 2026-04-08 at 15 19 42" src="https://github.com/user-attachments/assets/e110c09d-d90b-4984-8f4e-ba21977dca48" />
