### PR TITLE
fix macOS serial stalls

### DIFF
--- a/src/actions/deviceActions.ts
+++ b/src/actions/deviceActions.ts
@@ -513,19 +513,14 @@ export const open =
 
         clearInterval(updateRequestInterval);
         let renderIndex: number;
-        let lastRenderRequestTime = 0;
         updateRequestInterval = setInterval(
             () => {
-                const now = Date.now();
                 if (
                     renderIndex !== DataManager().getTotalSavedRecords() &&
                     getState().app.app.samplingRunning &&
-                    isDataLoggerPane(getState()) &&
-                    (DataManager().isInSync() ||
-                        now - lastRenderRequestTime >= 1000) // force 1 FPS
+                    isDataLoggerPane(getState())
                 ) {
-                    const timestamp = now;
-                    lastRenderRequestTime = now;
+                    const timestamp = Date.now();
                     if (getState().app.chart.liveMode) {
                         requestAnimationFrame(() => {
                             /*

--- a/src/components/Chart/Chart.tsx
+++ b/src/components/Chart/Chart.tsx
@@ -249,17 +249,14 @@ const Chart = () => {
         [dispatch],
     );
 
-    useHotkeyAction(HotkeyActionType.SELECT_ALL, () => {
+    const hotkeySelectAllCb = useCallback(() => {
         if (DataManager().getTimestamp() > 0) {
             chartCursor(0, DataManager().getTimestamp());
         }
-    });
+    }, [chartCursor]);
+    useHotkeyAction(HotkeyActionType.SELECT_ALL, hotkeySelectAllCb);
 
-    useHotkeyAction(HotkeyActionType.SELECT_NONE, () => {
-        resetCursor();
-    });
-
-    useHotkeyAction(HotkeyActionType.ZOOM_TO_SELECTION, () => {
+    const hotkeyZoomToSelectionCb = useCallback(() => {
         const zoomToSelectedArea =
             (): AppThunk<RootState> => (_dispatch, getState) => {
                 const { cursorBegin, cursorEnd } = getCursorRange(getState());
@@ -269,7 +266,11 @@ const Chart = () => {
             };
 
         dispatch(zoomToSelectedArea());
-    });
+    }, [dispatch, chartWindow]);
+    useHotkeyAction(
+        HotkeyActionType.ZOOM_TO_SELECTION,
+        hotkeyZoomToSelectionCb,
+    );
 
     const { digitalChannels, digitalChannelsVisible } = useSelector(
         getChartDigitalChannelInfo,
@@ -315,6 +316,7 @@ const Chart = () => {
         selectionStateAbortController.current?.abort();
         chartCursor(null, null);
     }, [chartCursor]);
+    useHotkeyAction(HotkeyActionType.SELECT_NONE, resetCursor);
 
     const zoomPanCallback = useCallback(
         (
@@ -449,6 +451,7 @@ const Chart = () => {
             );
             return () => {
                 clearTimeout(debounce);
+                selectionStateAbortController.current?.abort();
             };
         }
 

--- a/src/components/Chart/ChartTop.tsx
+++ b/src/components/Chart/ChartTop.tsx
@@ -133,7 +133,7 @@ const ChartTop = ({
                     </div>
                     <div className="tw-w-38 tw-order-1 tw-flex tw-flex-row tw-justify-end">
                         <Toggle
-                            label={`${live ? `(${fps} FPS) ` : ''}LIVE VIEW`}
+                            label={`${live && fps > 0 ? `(${fps} FPS) ` : ''}LIVE VIEW`}
                             onToggle={onLiveModeChange}
                             isToggled={live}
                             variant="primary"

--- a/src/components/Chart/data/dataAccumulator.ts
+++ b/src/components/Chart/data/dataAccumulator.ts
@@ -41,7 +41,10 @@ export const calcStats = (
     end = Math.min(normalizeTimeFloor(end), DataManager().getTimestamp());
 
     const maxNumberOfSamplesToProcess = 10_000_000;
-    const buffer = Buffer.alloc(maxNumberOfSamplesToProcess * frameSize);
+    const totalSamples = timestampToIndex(end) - timestampToIndex(begin) + 1;
+    const buffer = Buffer.alloc(
+        Math.min(totalSamples, maxNumberOfSamplesToProcess) * frameSize,
+    );
 
     let sum = 0;
     let len = 0;
@@ -149,7 +152,11 @@ const accumulate = async (
 
     const bytesToRead =
         (timestampToIndex(end) - timestampToIndex(begin) + 1) * frameSize;
-    if (!globalReadBuffer || globalReadBuffer.length < bytesToRead) {
+    if (
+        !globalReadBuffer ||
+        globalReadBuffer.length < bytesToRead ||
+        globalReadBuffer.length > bytesToRead * 4
+    ) {
         globalReadBuffer = Buffer.alloc(bytesToRead);
     }
 
@@ -489,6 +496,7 @@ const compareDigitalChanel = (rhs: number[], lhs: number[]) =>
 
 export const resetCache = () => {
     cachedResult = undefined;
+    globalReadBuffer = undefined;
 };
 
 export type DataAccumulatorInitialiser = () => DataAccumulator;

--- a/src/device/__tests__/serialDevice.test.ts
+++ b/src/device/__tests__/serialDevice.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports, global-require */
+
+import EventEmitter from 'events';
+
+const mockChild = Object.assign(new EventEmitter(), {
+    send: jest.fn(),
+    kill: jest.fn(),
+    pid: 12345,
+    connected: true,
+    disconnect: jest.fn(),
+    unref: jest.fn(),
+    ref: jest.fn(),
+    killed: false,
+    exitCode: null,
+    signalCode: null,
+    channel: undefined,
+    stdio: [null, null, null, null],
+    stdin: null,
+    stdout: null,
+    stderr: null,
+});
+
+jest.mock('@nordicsemiconductor/pc-nrfconnect-shared', () => ({
+    getAppDir: jest.fn(() => '/mock/app'),
+    logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+    },
+}));
+
+jest.mock(
+    '@nordicsemiconductor/pc-nrfconnect-shared/nrfutil/device/common',
+    () => ({}),
+);
+
+jest.mock('child_process', () => ({
+    fork: jest.fn(() => mockChild),
+}));
+
+const originalPlatform = process.platform;
+
+describe('SerialDevice', () => {
+    const mockDevice = {
+        serialPorts: [{ comName: '/dev/tty.test' }],
+    };
+    const mockCallback = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockChild.removeAllListeners();
+    });
+
+    afterAll(() => {
+        Object.defineProperty(process, 'platform', {
+            value: originalPlatform,
+        });
+    });
+
+    function loadSerialDevice() {
+        const { fork } = require('child_process');
+        const { default: SerialDevice } = require('../serialDevice');
+        const { logger } = require('@nordicsemiconductor/pc-nrfconnect-shared');
+        return { SerialDevice, fork, logger };
+    }
+
+    test('uses serialDevice.darwin.js worker on macOS', () => {
+        Object.defineProperty(process, 'platform', { value: 'darwin' });
+        jest.resetModules();
+
+        const { SerialDevice, fork } = loadSerialDevice();
+        const device = new SerialDevice(mockDevice, mockCallback);
+
+        expect(device).toBeDefined();
+        expect(fork).toHaveBeenCalledWith(
+            expect.stringContaining('serialDevice.darwin.js'),
+        );
+    });
+
+    test('uses serialDevice.js worker on Linux', () => {
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        jest.resetModules();
+
+        const { SerialDevice, fork } = loadSerialDevice();
+        const device = new SerialDevice(mockDevice, mockCallback);
+
+        expect(device).toBeDefined();
+        expect(fork).toHaveBeenCalledWith(
+            expect.stringContaining('serialDevice.js'),
+        );
+        expect(fork).not.toHaveBeenCalledWith(
+            expect.stringContaining('darwin'),
+        );
+    });
+
+    test('uses serialDevice.js worker on Windows', () => {
+        Object.defineProperty(process, 'platform', { value: 'win32' });
+        jest.resetModules();
+
+        const { SerialDevice, fork } = loadSerialDevice();
+        const device = new SerialDevice(mockDevice, mockCallback);
+
+        expect(device).toBeDefined();
+        expect(fork).toHaveBeenCalledWith(
+            expect.stringContaining('serialDevice.js'),
+        );
+        expect(fork).not.toHaveBeenCalledWith(
+            expect.stringContaining('darwin'),
+        );
+    });
+
+    test('logs error messages from worker via logger.error', () => {
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        jest.resetModules();
+
+        const { SerialDevice, logger } = loadSerialDevice();
+        const device = new SerialDevice(mockDevice, mockCallback);
+        device.parser = jest.fn();
+
+        mockChild.emit('message', { error: 'PPK command failed' });
+
+        expect(logger.error).toHaveBeenCalledWith('PPK command failed');
+    });
+
+    test('passes buffer data to parser', () => {
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+        jest.resetModules();
+
+        const { SerialDevice } = loadSerialDevice();
+        const device = new SerialDevice(mockDevice, mockCallback);
+        const parserMock = jest.fn();
+        device.parser = parserMock;
+
+        const testData = [1, 2, 3, 4];
+        mockChild.emit('message', { type: 'Buffer', data: testData });
+
+        expect(parserMock).toHaveBeenCalledWith(Buffer.from(testData));
+    });
+});

--- a/src/device/serialDevice.ts
+++ b/src/device/serialDevice.ts
@@ -92,9 +92,11 @@ class SerialDevice extends Device {
             samples: 3,
         };
         this.path = device.serialPorts?.at(0)?.comName;
-        this.child = fork(
-            path.resolve(getAppDir(), 'worker', 'serialDevice.js'),
-        );
+        const workerFile =
+            process.platform === 'darwin'
+                ? 'serialDevice.darwin.js'
+                : 'serialDevice.js';
+        this.child = fork(path.resolve(getAppDir(), 'worker', workerFile));
         this.parser = null;
         this.resetDataLossCounter();
 
@@ -106,6 +108,10 @@ class SerialDevice extends Device {
 
             if ('data' in message && message.data) {
                 this.parser(Buffer.from(message.data));
+                return;
+            }
+            if ('error' in message) {
+                logger.error(message.error);
                 return;
             }
             console.log(`message: ${JSON.stringify(message)}`);

--- a/src/device/types.ts
+++ b/src/device/types.ts
@@ -37,10 +37,15 @@ export interface bufferMessage {
     data: Array<number>;
 }
 
+export interface errorMessage {
+    error: string;
+}
+
 export type serialDeviceMessage =
     | openingMessage
     | startedMessage
-    | bufferMessage;
+    | bufferMessage
+    | errorMessage;
 
 export interface Mask {
     pos: number;

--- a/src/utils/FileBuffer.ts
+++ b/src/utils/FileBuffer.ts
@@ -498,11 +498,29 @@ export class FileBuffer {
             this.#cancelBufferOperations.get(op)?.abort();
         });
 
-        const bytesRead = await this.#readRange(
+        let bytesRead = await this.#readRange(
             buffer,
             numberOfBytesToRead,
             byteOffset,
         );
+
+        // The active write page may not yet be flushed to disk; supplement
+        // any short read from the in-memory write buffer.
+        if (bytesRead < numberOfBytesToRead && this.#writeBuffer) {
+            const supplementOffset = byteOffset + bytesRead;
+            const supplementLength = numberOfBytesToRead - bytesRead;
+            try {
+                readFromCachedData(
+                    this.#writeBuffer.getPages(),
+                    buffer.subarray(bytesRead),
+                    supplementOffset,
+                    supplementLength,
+                );
+                bytesRead = numberOfBytesToRead;
+            } catch {
+                // write buffer doesn't cover this range either
+            }
+        }
 
         const normalizedBegin =
             Math.ceil(byteOffset / this.#bufferPageSize) * this.#bufferPageSize;

--- a/src/utils/__tests__/fileBuffer.test.ts
+++ b/src/utils/__tests__/fileBuffer.test.ts
@@ -491,4 +491,43 @@ describe('ReadBuffers', () => {
             expect.anything(),
         ); // Buffer right
     });
+
+    test('Short disk read is supplemented from in-memory write buffer', async () => {
+        // After beforeEach: 6 bytes written [0,1,2,3,4,5], 3 write pages full.
+        // Append one more byte to push the oldest write page out of cache.
+        await fileBuffer.append(Buffer.from([6]));
+        // Write buffer now holds pages [2,3], [4,5], [6].
+        // Page [0,1] was evicted — only on disk.
+
+        // Mock fs.read to return a short read: only 6 bytes of 7 requested,
+        // simulating the unflushed write page not yet on disk.
+        castToJest(fs.read).mockImplementationOnce(
+            (
+                _fd: number,
+                buffer: Uint8Array,
+                _offset: number,
+                _length: number,
+                position: fs.ReadPosition | null,
+                callback: (
+                    err: NodeJS.ErrnoException | null,
+                    bytesRead: number,
+                    buffer: Uint8Array,
+                ) => void,
+            ) => {
+                const shortRead = 6;
+                for (let i = 0; i < shortRead; i += 1) {
+                    buffer[i] = Number(position) + i;
+                }
+                callback(null, shortRead, buffer);
+            },
+        );
+
+        const numberOfBytes = await fileBuffer.read(readBuffer, 0, 7);
+
+        expect(fs.read).toBeCalledTimes(1);
+        expect(numberOfBytes).toEqual(7);
+        expect(readBuffer.subarray(0, numberOfBytes)).toStrictEqual(
+            Buffer.from([0, 1, 2, 3, 4, 5, 6]),
+        );
+    });
 });

--- a/worker/serialDevice.darwin.js
+++ b/worker/serialDevice.darwin.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+// macOS-specific serial worker.
+//
+// Identical to serialDevice.js except that after port.open() the native
+// binding's read() is replaced with a polling loop.  This works around a
+// known macOS kqueue bug where uv_poll_start(UV_READABLE) silently stops
+// delivering notifications for USB CDC tty file descriptors after
+// approximately 60-90 minutes of continuous data.
+//
+// The polling approach mirrors what pyserial does (ioctl(TIOCINQ) +
+// synchronous read) and has been verified over 5+ hour sessions.
+//
+// See: https://github.com/serialport/node-serialport/issues/2787
+//      https://github.com/libuv/libuv/issues/2428
+
+const { resolve } = require('path');
+const fs = require('fs');
+
+const { execPath } = process;
+
+const asarPath = (() => {
+    if (/node_modules/.test(execPath)) {
+        return resolve(execPath.split('node_modules')[0]);
+    }
+    return resolve(execPath.split('/Frameworks/')[0], 'Resources', 'app.asar');
+})();
+
+// eslint-disable-next-line import/no-dynamic-require
+const { SerialPort } = require(resolve(asarPath, 'node_modules', 'serialport'));
+
+let port = null;
+process.on('message', msg => {
+    if (msg.open) {
+        console.log('\x1b[2J'); // ansi clear screen
+        process.send({ opening: msg.open });
+        port = new SerialPort({
+            path: msg.open,
+            autoOpen: false,
+            baudRate: 115200,
+        });
+
+        let data = Buffer.alloc(0);
+        port.on('data', buf => {
+            data = Buffer.concat([data, buf]);
+        });
+        setInterval(() => {
+            if (data.length === 0) return;
+            process.send(data.slice(), err => {
+                if (err) console.log(err);
+            });
+            data = Buffer.alloc(0);
+        }, 30);
+        port.open(err => {
+            if (err) {
+                process.send({ error: err.toString() });
+                return;
+            }
+
+            // Replace the native binding's kqueue-based read with a polling
+            // loop so that data delivery does not depend on uv_poll.
+            const binding = port.port;
+            if (binding) {
+                const fd = binding.fd;
+                const readBuf = Buffer.allocUnsafe(65536);
+
+                binding.read = function pollingRead(buffer, offset, length) {
+                    return new Promise((res, reject) => {
+                        const poll = () => {
+                            fs.read(
+                                fd,
+                                readBuf,
+                                0,
+                                Math.min(length, readBuf.length),
+                                null,
+                                (fsErr, bytesRead) => {
+                                    if (fsErr) {
+                                        if (
+                                            fsErr.code === 'EAGAIN' ||
+                                            fsErr.code === 'EWOULDBLOCK'
+                                        ) {
+                                            setTimeout(poll, 1);
+                                            return;
+                                        }
+                                        reject(fsErr);
+                                        return;
+                                    }
+                                    if (bytesRead > 0) {
+                                        readBuf.copy(
+                                            buffer,
+                                            offset,
+                                            0,
+                                            bytesRead,
+                                        );
+                                        res({ bytesRead, buffer });
+                                        return;
+                                    }
+                                    setTimeout(poll, 1);
+                                },
+                            );
+                        };
+                        poll();
+                    });
+                };
+                console.log(`Polling read active (kqueue bypass, fd=${fd})`);
+            }
+
+            process.send({ started: msg.open });
+        });
+    }
+    if (msg.write) {
+        port.write(msg.write, err => {
+            if (err) {
+                process.send({ error: 'PPK command failed' });
+            }
+        });
+    }
+});
+
+process.on('disconnect', () => {
+    console.log('parent process disconnected, cleaning up');
+    if (port) {
+        port.close(process.exit);
+    } else {
+        process.exit();
+    }
+});


### PR DESCRIPTION
# Fix macOS serial stall and Live View performance issues

I had several long sessions with Opus trying to track down the problem with the data logger stalling out and only showing 1 FPS in the UI.  Investigated leaks, fixed bugs, and I was pretty close to reverse-engineering the PPK2 firmware with Ghidra.  However, the key insight came when I was able to use https://github.com/IRNAS/ppk2-api-python with my PPK2 for 12+ hours yesterday.

Notably, for pyserial:

Default Behavior: Standard pyserial relies on select() or termios to interact with PTYs (pseudo-terminals) on macOS.
Limitations: On macOS, kqueue() does not reliably support PTYs or /dev/null for checking data availability, leading to a fallback to select().

The serial.darwin worker is effectively a monkey patch to avoid kqueue and use fs.read instead.  This is the easiest change with the largest immediate gain.  I think long term strategy would be to either upstream a polling interface to serialport, or use a USB CDC driver.  Web Serial API was also considered, but it ultimately depends on serialport/kqueue as well.

Here's the Copilot/Opus synopsis of our changes:

## Problem

  On macOS, long-running data logger sessions (60-90+ minutes) silently stop receiving serial data. The Live View chart freezes and displays "(0 FPS)" while the rest of the UI remains responsive. The PPK2 hardware continues sampling — the problem is entirely on the host side.

## Root Cause

  macOS's kqueue mechanism silently stops delivering readable events for USB CDC tty file descriptors after prolonged continuous use. This is a known libuv/kqueue interaction issue (libuv#2428 (https://github.com/libuv/libuv/issues/2428), node-serialport#2787 (
  https://github.com/serialport/node-serialport/issues/2787)). The @serialport/bindings-cpp read chain depends entirely on kqueue for read notification — once it stops, the data pipeline stalls with no error.

  Separately, even before the stall, GC pressure from buffer over-allocation and per-frame closure churn could cause the isInSync() guard to falsely throttle chart updates to 1 FPS.

## Changes

   1. macOS polling serial worker — A dedicated serialDevice.darwin.js worker replaces the kqueue-dependent binding.read() with a fs.read() + setTimeout polling loop, matching pyserial's approach (which was confirmed stall-free over 8+ hours). The main process selects the correct worker based on process.platform. 
  Linux/Windows remain unchanged.
   2. Memory pressure reduction — Stable-ref pattern for useHotkeyAction (eliminates ~90 subscribe/unsubscribe cycles/sec), right-sized calcStats buffer allocation (60 KB vs 60 MB for typical selections), shrinkable globalReadBuffer, and proper AbortController cleanup.
   3. Remove isInSync gate from DataLogger render loop — The guard was a self-described "temporary fix" that had no useful effect in DataLogger mode other than throttling to 1 FPS after transient GC pauses. Retained in Scope/Trigger mode where it's legitimately needed.
   4. FileBuffer short-read supplement — When the active write page hasn't been flushed to disk, read() now supplements the short disk read from the in-memory write buffer instead of returning incomplete data.
   5. Hide stale FPS counter — Suppress the misleading "(0 FPS)" label when no frames are rendering.

## Testing

   - Verified 5+ hour continuous session on macOS with polling worker — no stalls
   - 70 unit tests passing (6 new: FileBuffer short-read supplement, platform-based worker selection, worker error forwarding, data parsing)
   - Lint, TypeScript, and build all clean


