### PR TITLE
Fix: Less unnecessary builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,7 @@ on:
             ref:
                 description: 'The branch or tag to build'
     pull_request:
-        types:
-            - opened
-            - reopened
-            - synchronize
-            - labeled
+        types: [opened, reopened, synchronize]
 
 jobs:
     build:


### PR DESCRIPTION
When a pull request is labeled, there is no need to trigger a build.