### PR TITLE
Fix "Recover" button wrap

### DIFF
--- a/src/features/recovery/RecoveryDialogs.tsx
+++ b/src/features/recovery/RecoveryDialogs.tsx
@@ -60,7 +60,7 @@ const SessionItem = ({
                     <div className="tw-flex tw-flex-row tw-gap-2">
                         <Button
                             variant="secondary"
-                            className="tw-w-[62px]"
+                            className="tw-w-[62px] tw-border-white"
                             onClick={() => setShowDeleteConfirmation(true)}
                         >
                             Delete
@@ -84,7 +84,7 @@ const SessionItem = ({
                         <div className="tw-flex tw-flex-row tw-gap-2">
                             <Button
                                 variant="secondary"
-                                className="tw-w-[60px]"
+                                className="tw-w-[60px] tw-border-white"
                                 onClick={() => setShowDeleteConfirmation(false)}
                             >
                                 Cancel

--- a/src/features/recovery/RecoveryDialogs.tsx
+++ b/src/features/recovery/RecoveryDialogs.tsx
@@ -60,14 +60,14 @@ const SessionItem = ({
                     <div className="tw-flex tw-flex-row tw-gap-2">
                         <Button
                             variant="secondary"
-                            className="tw-w-[60px]"
+                            className="tw-w-[62px]"
                             onClick={() => setShowDeleteConfirmation(true)}
                         >
                             Delete
                         </Button>
                         <Button
                             variant="primary"
-                            className="tw-w-[60px]"
+                            className="tw-w-[62px]"
                             onClick={() => onRecoverClick(session)}
                         >
                             Recover

--- a/src/features/recovery/RecoveryDialogs.tsx
+++ b/src/features/recovery/RecoveryDialogs.tsx
@@ -60,14 +60,13 @@ const SessionItem = ({
                     <div className="tw-flex tw-flex-row tw-gap-2">
                         <Button
                             variant="secondary"
-                            className="tw-w-[62px] tw-border-white"
+                            className=" tw-border-white"
                             onClick={() => setShowDeleteConfirmation(true)}
                         >
                             Delete
                         </Button>
                         <Button
                             variant="primary"
-                            className="tw-w-[62px]"
                             onClick={() => onRecoverClick(session)}
                         >
                             Recover
@@ -84,14 +83,13 @@ const SessionItem = ({
                         <div className="tw-flex tw-flex-row tw-gap-2">
                             <Button
                                 variant="secondary"
-                                className="tw-w-[60px] tw-border-white"
+                                className=" tw-border-white"
                                 onClick={() => setShowDeleteConfirmation(false)}
                             >
                                 Cancel
                             </Button>
                             <Button
                                 variant="danger"
-                                className="tw-w-[60px]"
                                 onClick={() => onRemoveClick(session)}
                             >
                                 Delete

--- a/src/features/recovery/RecoveryDialogs.tsx
+++ b/src/features/recovery/RecoveryDialogs.tsx
@@ -60,7 +60,7 @@ const SessionItem = ({
                     <div className="tw-flex tw-flex-row tw-gap-2">
                         <Button
                             variant="secondary"
-                            className=" tw-border-white"
+                            className="tw-border-white"
                             onClick={() => setShowDeleteConfirmation(true)}
                         >
                             Delete
@@ -83,7 +83,7 @@ const SessionItem = ({
                         <div className="tw-flex tw-flex-row tw-gap-2">
                             <Button
                                 variant="secondary"
-                                className=" tw-border-white"
+                                className="tw-border-white"
                                 onClick={() => setShowDeleteConfirmation(false)}
                             >
                                 Cancel


### PR DESCRIPTION
https://nordicsemi.atlassian.net/browse/NCD-1647

Reason for this to happen is that Button component has `tw-border tw-border-nordicBlue` classes, for some reason they did not appear in classes with older shared but appear now. 
Just added a bit of a width to allow text to fit into the box. Almost no visual difference.

PR also adds white border, because current border is same as bg color => visually button height is smaller than it should be