### PR TITLE
Cleanup workflow to notify swtools-app-docs workflow

### DIFF
--- a/.github/workflows/docs-notify-swtools-repo.yml
+++ b/.github/workflows/docs-notify-swtools-repo.yml
@@ -12,7 +12,7 @@ on:
       ref:
         description: Ref to read the release version from (branch, tag, or SHA)
         type: string
-        required: false
+        required: true
 
 jobs:
   notify:

--- a/.github/workflows/docs-notify-swtools-repo.yml
+++ b/.github/workflows/docs-notify-swtools-repo.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name != 'release'
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Resolve release tag
         id: tag

--- a/.github/workflows/docs-notify-swtools-repo.yml
+++ b/.github/workflows/docs-notify-swtools-repo.yml
@@ -38,7 +38,7 @@ jobs:
             await github.rest.repos.createDispatchEvent({
               owner: 'nordicsemi',
               repo: 'swtools-app-docs',
-              event_type: 'app-release',
+              event_type: 'bump-project-tag',
               client_payload: {
                 project: 'pc-nrfconnect-ppk',
                 tag: `v${version}`,

--- a/.github/workflows/docs-notify-swtools-repo.yml
+++ b/.github/workflows/docs-notify-swtools-repo.yml
@@ -1,8 +1,6 @@
 name: Notify swtools-app-docs about release
 
 on:
-  release:
-    types: [published]
   workflow_call:
     inputs:
       ref:
@@ -21,22 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name != 'release'
         with:
           ref: ${{ inputs.ref }}
-
-      - name: Resolve release tag
-        id: tag
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
-        run: |
-          if [ "$EVENT_NAME" = "release" ] && [ -n "$RELEASE_TAG" ]; then
-            echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-          else
-            VERSION=$(node -p "require('./package.json').version")
-            echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
-          fi
 
       - uses: actions/create-github-app-token@v3
         id: app-token
@@ -50,14 +34,14 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const tag = '${{ steps.tag.outputs.tag }}';
+            const version = require('./package.json').version;
             await github.rest.repos.createDispatchEvent({
               owner: 'nordicsemi',
               repo: 'swtools-app-docs',
               event_type: 'app-release',
               client_payload: {
                 project: 'pc-nrfconnect-ppk',
-                tag,
+                tag: `v${version}`,
                 repo: 'https://github.com/nordicsemi/pc-nrfconnect-ppk',
               },
             });

--- a/.github/workflows/docs-notify-swtools-repo.yml
+++ b/.github/workflows/docs-notify-swtools-repo.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.JENKINS_NCS_APP_ID }}
+          client-id: ${{ secrets.JENKINS_NCS_APP_ID }}
           private-key: ${{ secrets.JENKINS_NCS_APP_PRIVATE_KEY }}
           owner: nordicsemi
           repositories: swtools-app-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,5 @@ jobs:
         if: inputs.source == 'official (external)'
         uses: ./.github/workflows/docs-notify-swtools-repo.yml
         with:
-            ref: ${{ inputs.ref || github.ref }}
+            ref: ${{ inputs.ref }}
         secrets: inherit


### PR DESCRIPTION
This should eventually be moved to shared, probably replacing [the code at the end of `release-app.yml`](https://github.com/nordicsemi/pc-nrfconnect-shared/blob/92f7df8063806d7ae62f71f5cd17c19d6756d463/.github/workflows/release-app.yml#L105-L115). But before that I want to clean it up here.