### PR TITLE
Fix: Relative timestamps as tooltips 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- If “Absolute” timestamps are selected in the display options, the tooltip was
+  still a relative timestamp.
+
 ## 4.4.0 - 2026-05-21
 
 ### Added

--- a/src/components/Chart/AmpereChart.tsx
+++ b/src/components/Chart/AmpereChart.tsx
@@ -252,7 +252,11 @@ export default ({
         parsing: false,
         maintainAspectRatio: false,
         animation: false,
-        formatX: timestampToLabel,
+        formatX: value =>
+            timestampToLabel(
+                value,
+                systemTime ? DataManager().getStartSystemTime() : undefined,
+            ),
         formatY: formatCurrent,
         snapping,
         live,

--- a/src/components/Chart/AmpereChart.tsx
+++ b/src/components/Chart/AmpereChart.tsx
@@ -105,12 +105,16 @@ const formatCurrent = (nA: number) =>
 
 const padL = (nr: number, len = 2, chr = `0`) => `${nr}`.padStart(len, chr);
 
-const timestampToLabel = (usecs: number, systemTime?: number) => {
+const timestampToLabel = (usecs: number, useSystemTime: boolean) => {
     const microseconds = Math.abs(usecs);
 
-    if (systemTime != null) {
+    const systemStartTime = useSystemTime
+        ? DataManager().getStartSystemTime()
+        : null;
+
+    if (systemStartTime != null) {
         const milliSeconds = Math.trunc(microseconds / 1000);
-        const time = new Date(milliSeconds + systemTime);
+        const time = new Date(milliSeconds + systemStartTime);
         const subsecond =
             Number(
                 ((microseconds + time.getMilliseconds() * 1000) / 1e3) % 1e3,
@@ -211,9 +215,7 @@ export default ({
                     callback: value =>
                         timestampToLabel(
                             Number.parseInt(value.toString(), 10),
-                            systemTime
-                                ? DataManager().getStartSystemTime()
-                                : undefined,
+                            systemTime,
                         ),
                     maxTicksLimit: 7,
                 },
@@ -252,11 +254,7 @@ export default ({
         parsing: false,
         maintainAspectRatio: false,
         animation: false,
-        formatX: value =>
-            timestampToLabel(
-                value,
-                systemTime ? DataManager().getStartSystemTime() : undefined,
-            ),
+        formatX: value => timestampToLabel(value, systemTime),
         formatY: formatCurrent,
         snapping,
         live,


### PR DESCRIPTION
If “Absolute” timestamps are selected in the display options, the tooltip was still a relative timestamp.

The previous UI is shown in #612, with this change it would look like this: 
<img width="1525" height="871" alt="image" src="https://github.com/user-attachments/assets/c73e6bb2-c738-4164-9033-3e7efc4fff15" />
 